### PR TITLE
Fix/TBDSITES-280-heart_image_position

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,7 +23,7 @@ export default function Home() {
           />
           <img
             src="/img/static-vertical-cyan.svg"
-            className="absolute right-[-1.5rem] tablet:right-[-2.1875rem] desktop:right-[-9rem] bottom-[13vh] tablet:bottom-[-9.5rem] desktop:bottom-[2.5rem] "
+            className="absolute right-[-1.5rem] tablet:right-[-2.1875rem] desktop:right-[-12rem] bottom-[13vh] tablet:bottom-[-9.5rem] desktop:bottom-[1.5rem] "
             alt=""
           />
           <img


### PR DESCRIPTION
With this positioning the blue illustration is not going to show in lower desktop resolution because the margins are smaller than in the designs