### PR TITLE
fix: Make the CTA Buttons wrap to the next line when there is no space

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.jsx
+++ b/src/components/ButtonGroup/ButtonGroup.jsx
@@ -4,11 +4,7 @@ import { Button } from '../Button';
 
 const ButtonGroup = ({ buttons, className, invertDarkMode }) => {
   return (
-    <div
-      className={`flex gap-4 flex-wrap flex-col desktop:flex-row ${
-        className ?? ''
-      }`}
-    >
+    <div className={`flex gap-4 flex-wrap ${className ?? ''}`}>
       {buttons.map((button) => (
         <div key={button.data.label} className="w-fit">
           <Button


### PR DESCRIPTION
instead of change to a vertical layout on tablet breakpoint