### PR TITLE
fix: removes duplicate tooltip highlight on tbDEX

### DIFF
--- a/src/pages/projects/tbdex.mdx
+++ b/src/pages/projects/tbdex.mdx
@@ -43,7 +43,7 @@ A <TooltipWrapper trigger="decentralized">a network that is not controlled by a 
 
 So now we have both legacy payment systems and new payment systems. But how do we get from the old to the new? tbDEX bridges the worlds of legacy money and digital money.
 
-tbDEX is a decentralized, <TooltipWrapper trigger="permissionless">the ability to participate in a network without the need for application or approval</TooltipWrapper> protocol. It opens the door to <TooltipWrapper trigger="Self Sovereign Identity">an approach that gives individuals ownership and control of their digital identities</TooltipWrapper> and access to the financial system for all. And because it abstracts away the complexity of decentralization, developers can focus on building great things.
+tbDEX is a decentralized, permissionless protocol. It opens the door to <TooltipWrapper trigger="Self Sovereign Identity">an approach that gives individuals ownership and control of their digital identities</TooltipWrapper> and access to the financial system for all. And because it abstracts away the complexity of decentralization, developers can focus on building great things.
 
 <ButtonGroup
   className="pt-16"


### PR DESCRIPTION
removes duplicate highlight from 'permissionless'
Resolves: #448