### PR TITLE
Bug: Broken link in blog post, Missing https:// protocol

### DIFF
--- a/blog/2022-10-13-announcing-the-incubation-program.md
+++ b/blog/2022-10-13-announcing-the-incubation-program.md
@@ -33,7 +33,7 @@ and Governance model,
 fostering an inclusive community. Incubation projects 
 benefit from TBD’s open source programs including 
 [GitHub](https://github.com/TBD54566975), 
-[TBD Forums](forums.tbd.website), 
+[TBD Forums](https://forums.tbd.website), 
 and our [Discord](https://discord.gg/tbd) server.
 
 When projects reach maturity, they may apply to be 


### PR DESCRIPTION
I noticed this link is broken on this blog post, it is missing the https:// protocol before the url which renders the link as a subpage of developer.tbd.website/blog. It might be beneficial to have a link check action on deployment. 