### PR TITLE
Fix Broken tbDEX Links

### DIFF
--- a/src/content/projects/tbdex/tbdex.js
+++ b/src/content/projects/tbdex/tbdex.js
@@ -28,7 +28,8 @@ export const content = {
         title: 'Decentralized Web Node',
         description: TBDEXProtocol,
         textButton: 'View Component',
-        url: '/projects/dwn-sdk-js/README',
+        url: 'https://github.com/TBD54566975/dwn-sdk-js#readme',
+        isExternalLink: true,
       },
       {
         icon: '/img/component-icon.svg',
@@ -45,14 +46,16 @@ export const content = {
         description:
           'An in-a-box service that handles the full Verifiable Credentials lifecycle, including issuance, verification, revocation, and more.',
         textButton: 'View Component',
-        url: '/projects/ssi-service/README',
+        url: 'https://github.com/TBD54566975/ssi-service#readme',
+        isExternalLink: true,
       },
       {
         icon: '/img/component-icon.svg',
         title: 'Self-Sovereign Identity SDK',
         description: SSIService,
         textButton: 'View Component',
-        url: '/projects/ssi-sdk/README',
+        url: 'https://github.com/TBD54566975/ssi-sdk/blob/main/README.md',
+        isExternalLink: true,
       },
     ],
   },

--- a/src/content/projects/tbdex/tbdex.js
+++ b/src/content/projects/tbdex/tbdex.js
@@ -54,7 +54,7 @@ export const content = {
         title: 'Self-Sovereign Identity SDK',
         description: SSIService,
         textButton: 'View Component',
-        url: 'https://github.com/TBD54566975/ssi-sdk/blob/main/README.md',
+        url: 'https://github.com/TBD54566975/ssi-sdk#readme',
         isExternalLink: true,
       },
     ],


### PR DESCRIPTION
Links to the Decentralised Web, SSI and SSI SDK project pages are broken. This solution is based on how the links were fixed for the web5 project page, which was fixed in this PR:
    
https://github.com/TBD54566975/developer.tbd.website/pull/328/files