### PR TITLE
Remove custom code block font size for tokens of type 'plain'

### DIFF
--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -159,11 +159,6 @@ article .markdown p code {
   background-color: gray;
 }
 
-.token.plain {
-  font-family: monospace;
-  font-size: 16px; 
-}
-
 .pagination-nav__sublabel {
   display: none;
 }

--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -161,6 +161,7 @@ article .markdown p code {
 
 .token.plain {
   font-family: monospace;
+  font-size: 16px; 
 }
 
 .pagination-nav__sublabel {

--- a/src/css/docs.css
+++ b/src/css/docs.css
@@ -161,7 +161,6 @@ article .markdown p code {
 
 .token.plain {
   font-family: monospace;
-  font-size: 18px;
 }
 
 .pagination-nav__sublabel {


### PR DESCRIPTION
This PR addresses font size of code block strings with token type "plain" 