### PR TITLE
Add link that points to Web5 SDK from API reference page

### DIFF
--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -7,6 +7,11 @@ import ApiCard from '@site/src/components/ApiCard';
 <div>
   <p>The Web5 API References provide access to the Web5 JS SDK, DWN JS SDK, the SSI SDK, and SSI Service API.</p>
   <div className="grid grid-cols-2 gap-4">
+  <ApiCard
+      url="https://tbd54566975.github.io/web5-js/"
+      name="Web5 JavaScript SDK"
+      description="The Web5 JS SDK provides a simple library for the necessary functionality needed to build Web5 apps at scale. It abstracts away much of the heavy-lifting and aims to make building Web5 apps as close to effortless as possible."
+    />
     <ApiCard
       url="/docs/apis/ssi-service"
       name="SSI Service API"
@@ -21,11 +26,6 @@ import ApiCard from '@site/src/components/ApiCard';
       url="https://pkg.go.dev/github.com/TBD54566975/ssi-sdk"
       name="SSI SDK - Go Docs"
       description=" The ssi-sdk intends to provide flexible functionality based on a set of standards-based primitives for building decentralized identity applications in a modular manner: with limited dependencies between components."
-    />
-    <ApiCard
-      url="https://tbd54566975.github.io/web5-js/"
-      name="Web5.js SDK"
-      description="The SDK sets out to gather the most of the used functionality from all three of these pillar technologies to provide a simple library that is as close to effortless as possible."
     />
   </div>
 </div>

--- a/docs/api/index.mdx
+++ b/docs/api/index.mdx
@@ -22,5 +22,10 @@ import ApiCard from '@site/src/components/ApiCard';
       name="SSI SDK - Go Docs"
       description=" The ssi-sdk intends to provide flexible functionality based on a set of standards-based primitives for building decentralized identity applications in a modular manner: with limited dependencies between components."
     />
+    <ApiCard
+      url="https://tbd54566975.github.io/web5-js/"
+      name="Web5.js SDK"
+      description="The SDK sets out to gather the most of the used functionality from all three of these pillar technologies to provide a simple library that is as close to effortless as possible."
+    />
   </div>
 </div>


### PR DESCRIPTION
This is simply adding the API on the reference page, however, I want to keep this as a draft until we can get a better description for it. This is what we currently have:

<img width="771" alt="Screenshot 2023-04-24 at 5 25 03 PM" src="https://user-images.githubusercontent.com/1852675/234120409-53279cf4-b044-4c72-bfc2-c73d4890f9ee.png">


The red box is the content I'd like to change, I just copy and pasted from the repo. Looking for someone to flesh this out with a better description.

@mistermoe can you or someone at OSE help out here?

Also cc devrel: @chris-tbd 