### PR TITLE
Build Folder and Record in Quickstart Updates 0.6.0

### DIFF
--- a/docs/web5/_quickstart-05-write-record.mdx
+++ b/docs/web5/_quickstart-05-write-record.mdx
@@ -18,7 +18,7 @@ A user can host their DWN in mulitple locations. The Web5 SDK is both browser an
 
 Add the following to `index.js`:
 ```js
-const myRecord = await web5.dwn.records.create(did.id, {
+const {record} = await web5.dwn.records.create(did.id, {
     author: did.id,
     data: "Hello Web5",
     message: {
@@ -35,7 +35,7 @@ const myRecord = await web5.dwn.records.create(did.id, {
 
   In <code>index.js</code>, add the following line and save your file:
   ```js
-  console.log('write result', myRecord);
+  console.log('write result', record);
   ```
 
   Then from the terminal, run:
@@ -45,25 +45,8 @@ const myRecord = await web5.dwn.records.create(did.id, {
 
   You'll see the record that was written to the user's DWN. It will resemble:
   ```js
-  write result {
-  status: { code: 202, detail: 'Accepted' },
-  entries: undefined,
-  data: undefined,
-  message: {
-    recordId: 'bafyreicc65viceyqtl7sjdxbbxpuvs2nlagerzcblje2lvfhzqbmg4pqhm',
-    descriptor: {
-      interface: 'Records',
-      method: 'Write',
-      dataCid: 'bafkreibr4hojx6b7ukyqkmlw3em4f3ssnlcgwe33wt4uijofkswxpqysje',
-      dataSize: 10,
-      dateCreated: '2023-04-25T18:52:45.550765Z',
-      dateModified: '2023-04-25T18:52:45.550765Z',
-      dataFormat: 'text/plain'
-    }
-  },
-  record: _Record {}
-}
-```
+    write result _Record {}
+  ```
   </p>
 </details>
 

--- a/docs/web5/_quickstart-06-read-record.mdx
+++ b/docs/web5/_quickstart-06-read-record.mdx
@@ -5,7 +5,7 @@ If the user has given your app read permissions to their DWN, you can read their
 
 To return the text data stored in the `record` add the following to `index.js`:
 ```js
-const readResult = await myRecord.record.data.text();
+const readResult = await record.data.text();
 ```
 
 <details>

--- a/docs/web5/_quickstart-07-update-record.mdx
+++ b/docs/web5/_quickstart-07-update-record.mdx
@@ -4,7 +4,7 @@ To update the record, call `update` on the `record` object itself.
 
 Add the following to `index.js`:
 ```js
-const updateResult = await myRecord.record.update({data: "Hello, I'm updated!"});
+const updateResult = await record.update({data: "Hello, I'm updated!"});
 ```
 
 <details>
@@ -13,7 +13,7 @@ const updateResult = await myRecord.record.update({data: "Hello, I'm updated!"})
 To see the record that was updated in the DWN, add the following to <code>index.js</code>:
 
 ```js
-console.log('Update result: ', await myRecord.record.data.text());
+console.log('Update result: ', await record.data.text());
 ```
 
 The output will resemble:

--- a/docs/web5/_quickstart-08-delete-record.mdx
+++ b/docs/web5/_quickstart-08-delete-record.mdx
@@ -4,7 +4,7 @@ Given permission from the user, your app can delete records from their DWN. Simi
 
 Add the following to `index.js`:
 ```js
-const deleteResult = await myRecord.record.delete();
+const deleteResult = await record.delete();
 ```
 
 <details>

--- a/docs/web5/build/apps/todo-app-tutorial.mdx
+++ b/docs/web5/build/apps/todo-app-tutorial.mdx
@@ -82,11 +82,10 @@ onMounted(async () => {
     const myDid = await web5.did.create('ion');
     registerInfo = {
       connected : true,
-      did       : myDid.id,
       endpoint  : 'app://dwn', 
       keys      : myDid.keys[0].keypair
   };
-  web5.did.manager.set(registerInfo);
+  web5.did.manager.set(myDid.id, registerInfo);
   dwnDID.value = registerInfo.did;
 }
 ```

--- a/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
+++ b/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
@@ -56,9 +56,9 @@ When calling `create`, be sure to pass in a Web5-supported DID method(). `create
 When you instantiate `Web5`, the SDK internally creates a Decentralized Web Node (DWN) to act as a personal data store to store your DID keys. In order to store your DID, save and encrypt your keys with the Web5 SDK.
 
 ```jsx
-    web5.did.manager.set(myDid.id, {
-      connected: true,
-      endpoint: 'app://dwn', 
-      keys: ["#dwn"]: { keyPair: myDid.keys[0].keypair }
-    });
+web5.did.manager.set(myDid.id, {
+   connected: true,
+   endpoint: 'app://dwn', 
+   keys: ["#dwn"]: { keyPair: myDid.keys[0].keypair }
+});
 ```

--- a/docs/web5/build/decentralized-identifiers/how-to-use-external-dids.mdx
+++ b/docs/web5/build/decentralized-identifiers/how-to-use-external-dids.mdx
@@ -11,12 +11,15 @@ const web5 = new Web5();
 const myDid = await web5.did.create('ion');
 
 // Save your newly created DID in your DWN
-web5.did.register({
-      connected: true,
-      did: myDid.id,
-      endpoint: 'app://dwn', 
-      keys: myDid.keys[0].keypair
-    });
+await web5.did.manager.set(myDid.id, {
+    connected: true,
+    endpoint: 'app://dwn', //this points to the user's local DWN
+    keys: {
+        ['#dwn']: {
+          keyPair: myDid.keys.find(key => key.id === 'dwn').keyPair,
+        },
+    },
+});
 ```
 
 In order to bring an external DID into your `Web5` project, simply replace the `myDid` object you created using `Web5` with the `did` data of the `did` you’d like to import. The structure of `myDid` is as follows:
@@ -53,34 +56,3 @@ In order to bring an external DID into your `Web5` project, simply replace the `
    ...
 }
 ```
-
-## Importing a DID from ssi-service
-
-If you’d like to practice importing a `did` created outside of `Web5`, you can do so by creating a `did` using the `ssi-service` library as follows:
-
-```jsx
-// This is how to bring your own key. You can create a key from the ssi service and import it into the dwn
-const web5 = new Web5();
-
-const myDidSSI = await ssisdk.createDIDKey()
-const keypair = {
-      id: "key-1",
-      type: "JsonWebKey2020",
-      keypair: {
-        publicJwk: myDidSSI.publicJWK,
-        privateJwk: myDidSSI.privateJWK
-      },
-      purposes: [
-        "authentication"
-      ]
-    }
-
-web5.did.manager.set({
-      connected: true,
-      did: myDidSSI.didDocument.id,
-      endpoint: 'app://dwn',
-      keys: keypair
-    });
-```
-
-As long as the `ssi-service` and `Web5` instances that are creating the keys live in the same application, this is perfectly safe to do. If, however, you have a separate application running `ssi-service` that generates a `did`, export that `did` to plain text or some other more portable format, and attempt to import that `did` document into your app, you’d be doing so in an unsafe manner.

--- a/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
+++ b/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
@@ -4,22 +4,21 @@ sidebar_position: 3
 
 # Delete Data from a Decentralized Web Node
 
-Before deleting from your Decentralized Web Node (DWN), be sure to check out our Quickstart page to ensure you’ve properly imported the Web5 SDK. Additionally, make sure you’ve set up a DID before attempting to delete from a DWN.
+Before deleting from your Decentralized Web Node (DWN), be sure to check out our [Quickstart guide](../../quickstart) to ensure you’ve properly imported the Web5 SDK. Additionally, make sure you’ve set up a DID before attempting to delete from a DWN.
 
 ## Deleting from a DWN
 
+The following snippet allows you to delete from your Web5 instance’s DWN:
+
 ```jsx
-const recordId = queryResponse.entries[0].recordId
-const deleteResponse = await web5.dwn.records.delete(myDid.id, {
-  author: myDid.id,
-  message: {
-     recordId: recordId
-  }
+// Create the record
+const myRecord = await web5.dwn.records.create(myDid.id, {
+    author: myDid.id,
+    data: "Hello Web5",
+    message: {
+        dataFormat: 'text/plain',
+    },
 });
+// Delete the record
+const deleteResult = await myRecord.record.delete();
 ```
-
-The delete `request` must contain the following:
-
-- **`author`** - *`string`*: The decentralized identifier of the DID signing the query. This may be the same as the `target` parameter if the target and the signer of the query are the same entity, which is common for an app querying the DWeb Node of its own user.
-- **`message`** - *`object`*: The prrties of the DWeb Node Message Descriptor that will be used to construct a valid DWeb Node message.
-    - **`recordId`** - *`string`*: the required record ID string that identifies the record being deleted.

--- a/docs/web5/build/decentralized-web-nodes/read-from-dwn.mdx
+++ b/docs/web5/build/decentralized-web-nodes/read-from-dwn.mdx
@@ -11,21 +11,14 @@ Before reading from your Decentralized Web Node (DWN), be sure to check out our 
 The following snippet allows you to read from your `Web5` instance’s DWN:
 
 ```jsx
-// Query for the record that was just created.
-const queryResponse = await web5.dwn.records.query(myDid.id, {
-  author: myDid.id,
-  message: {
-    filter: {
-      schema: 'schema.org/foo/bar'
-    }
-	}
+// Create the record
+const myRecord = await web5.dwn.records.create(myDid.id, {
+    author: myDid.id,
+    data: "Hello Web5",
+    message: {
+        dataFormat: 'text/plain',
+    },
 });
+// Read the record
+const readResult = await myRecord.record.data.text();
 ```
-
-The read `request` must contain the following:
-
-- **`author`** - *`string`*: The decentralized identifier of the DID signing the query. This may be the same as the `target` parameter if the target and the signer of the query are the same entity, which is common for an app querying the DWeb Node of its own user.
-- **`message`** - *`object`*: The properties of the DWeb Node Message Descriptor that will be used to construct a valid DWeb Node message. `schema` must be a resolvable
-- **`filter`** - *`object`*: an object that defines a set of properties to filter results.
-    - **`protocol`(optional)** - *`URI string`*: a URI that represents the protocol being queried for.
-    - **`schema`(optional)** - *`URI string`*: a URI that represents the schema being queried for.

--- a/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx
+++ b/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx
@@ -11,15 +11,15 @@ Before writing to your Decentralized Web Node (DWN), be sure to check out our [Q
 The following snippet allows you to write to your `Web5` instance’s DWN using a DID object called `myDid`:
 
 ```jsx
-// Write a plain text record to the in-memory DWN.
-    const response = await web5.dwn.records.write(myDid.id, {
-      author: myDid.id,
-      data: 'Hello, world!',
-      message: {
-        schema: 'schema.org/foo/bar',
-        dataFormat: 'text/plain'
-      }
-    });
+// Write a plain text record to the in-memory DWN
+
+const myRecord = await web5.dwn.records.create(myDid.id, {
+  author: myDid.id,
+  data: "Hello Web5",
+  message: {
+      dataFormat: 'text/plain',
+  },
+});
 ```
 
 The write `request` must contain the following:

--- a/static/files/index.txt
+++ b/static/files/index.txt
@@ -4,44 +4,25 @@ const web5 = new Web5();
 const did = await web5.did.create('ion');
 
 await web5.did.manager.set(did.id, {
-  connected: true,
-  endpoint: 'app://dwn',
-  keys: {
-    ['#dwn']: {
-      keyPair: did.keys.find((key) => key.id === 'dwn').keyPair,
+    connected: true,
+    endpoint: 'app://dwn', //this points to the user's local DWN
+    keys: {
+        ['#dwn']: {
+          keyPair: did.keys.find(key => key.id === 'dwn').keyPair,
+        },
     },
-  },
 });
 
-const data = 'Hello Web5';
-
-const writeResult = await web5.dwn.records.write(did.id, {
-  author: did.id,
-  data,
-  message: {
-    dataFormat: 'text/plain',
-  },
-});
-
-const queryResult = await web5.dwn.records.query(did.id, {
-  author: did.id,
-  message: {
-    filter: {
-      dataFormat: 'text/plain',
+const {record} = await web5.dwn.records.create(did.id, {
+    author: did.id,
+    data: "Hello Web5",
+    message: {
+        dataFormat: 'text/plain',
     },
-  },
 });
 
-const readResult = await web5.dwn.records.read(did.id, {
-  author: did.id,
-  message: {
-    recordId: queryResult.entries[0].id,
-  },
-});
+const readResult = await record.data.text();
 
-const deleteResult = await web5.dwn.records.delete(did.id, {
-  author: did.id,
-  message: {
-    recordId: queryResult.entries[0].id,
-  },
-});
+const updateResult = await record.update({data: "Hello, I'm updated!"});
+
+const deleteResult = await record.delete();


### PR DESCRIPTION
Went ahead and found all places where code and copy needed to be updated to 0.6.0 (inline with Quickstart changes) and myRecord > record in Quickstart updated well.

One thing we didn't change yet in this PR was the Build > Apps > ToDo app because it's not a breaking change right now bc the app example pinned at the top is using 0.4.0 SDK.