### PR TITLE
Removed duplicate button on open Source page

### DIFF
--- a/src/content/open-source/open-source.js
+++ b/src/content/open-source/open-source.js
@@ -53,13 +53,6 @@ export const content = {
         isExternalLink: false
       },
     },
-    {
-      type: 'button',
-      data: {
-        label: 'Join our Incubation Program',
-        url: '/open-source/incubation',
-        isExternalLink: false
-      },
-    },
+
   ],
 };


### PR DESCRIPTION
There is  a duplicate button in [Open Source](https://developer.tbd.website/open-source) page , 
which is removed.

Files Changed : [open-source.js](https://github.com/TBD54566975/developer.tbd.website/blob/main/src/content/open-source/open-source.js).

Closes : #503 

Sreenshot of made changes:
![image](https://github.com/TBD54566975/developer.tbd.website/assets/105551807/ad290c62-375a-4918-af98-d1f67628080e)
