### PR TITLE
Issue #562 - Add Datadog analytics scripts

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -55,6 +55,16 @@ const config = {
       },
     ],
   ],
+  scripts: [
+    {
+      src: 'https://www.datadoghq-browser-agent.com/us1/v4/datadog-rum.js',
+      async: true
+    },
+    {
+      src: '/scripts/dd-analytics.js',
+      async: true
+    }
+  ],
   presets: [
     [
       'classic',

--- a/site/static/scripts/dd-analytics.js
+++ b/site/static/scripts/dd-analytics.js
@@ -1,0 +1,18 @@
+window.DD_RUM && window.DD_RUM.init({
+    clientToken: 'pub4c8b1a9ef4c424ef4d0ce30adaedc6d0',
+    applicationId: '3937f727-75df-40e8-bed7-84fd4ef7bcf6',
+    site: 'datadoghq.com',
+    service: 'tbd.website',
+    env: 'devtest',
+    // Specify a version number to identify the deployed version of your application in Datadog 
+    // version: '1.0.0',
+    sessionSampleRate: 100,
+    sessionReplaySampleRate: 20,
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+    defaultPrivacyLevel: 'mask-user-input',
+});
+
+window.DD_RUM &&
+window.DD_RUM.startSessionReplayRecording();


### PR DESCRIPTION
For Issue #562 

@dayhaysoos  - would you review this is where you'd expect us to put scripts that we want to fire on every page?

Let's hold on merging this until we confirm that the tracking is making it into the analytics Dashboard. Looks like it might be, based on traffic:

<img width="623" alt="image" src="https://github.com/TBD54566975/developer.tbd.website/assets/199891/3c2dd8ee-860b-4fca-bdaf-b23b0abf69aa">
