### PR TITLE
removing reference to src folder from Quickstart (issue #606)

### DIFF
--- a/site/docs/web5/_quickstart-03-create-did.mdx
+++ b/site/docs/web5/_quickstart-03-create-did.mdx
@@ -25,12 +25,14 @@ Web5 is split into three main top-level objects:
   <summary>Test your code</summary>
   <p>
 
-  Wanna see the DID you just created? In <code>index.js</code>, add the following line and save your file:
+  Wanna see the DID you just created? 
+  
+  In <code>index.js</code>, add the following line and save your file:
   ```js
   console.log(aliceDid);
   ```
 
-  Then from your CLI, run:
+  Then from the terminal, run:
   ```bash
   node index.js
   ```

--- a/site/docs/web5/_quickstart-05-write-record.mdx
+++ b/site/docs/web5/_quickstart-05-write-record.mdx
@@ -39,7 +39,7 @@ const { record } = await web5.dwn.records.create({
 
   Then from the terminal, run:
   ```bash
-  node src/index.js
+  node index.js
   ```
 
   You'll see the record that was written to the user's DWN. It will resemble:

--- a/site/docs/web5/_quickstart-06-read-record.mdx
+++ b/site/docs/web5/_quickstart-06-read-record.mdx
@@ -2,7 +2,7 @@
 
 ## 3. Read DWN Records
 
-If the user has given your app read permissions to their DWN, you can read their data by accessing it through the `record` property. If you don't already have access to the record, you can [query](/docs/web5/build/decentralized-web-nodes/update-to-dwn) to obtain it.
+If the user has given your app read permissions to their DWN, you can read their data by accessing it through the `record` property. If you don't already have access to the record, you can [query](/docs/web5/build/decentralized-web-nodes/query-from-dwn) to obtain it.
 
 To return the text data stored in the `record`, add the following to `index.js`:
 ```js
@@ -16,6 +16,12 @@ To see the record that was read from the DWN, add the following to <code>index.j
 
 ```js
 console.log('readResult', readResult)
+```
+
+Then from the terminal, run:
+
+```bash
+node index.js
 ```
 
 The output will resemble:

--- a/site/docs/web5/_quickstart-07-update-record.mdx
+++ b/site/docs/web5/_quickstart-07-update-record.mdx
@@ -18,6 +18,12 @@ To see the record that was updated in the DWN, add the following to <code>index.
 console.log('updateResult', await record.data.text())
 ```
 
+Then from the terminal, run:
+
+```bash
+node index.js
+```
+
 The output will resemble:
 ```
 updateResult Hello, I'm updated!

--- a/site/docs/web5/_quickstart-08-delete-record.mdx
+++ b/site/docs/web5/_quickstart-08-delete-record.mdx
@@ -18,6 +18,12 @@ To see the status of the delete transaction, add the following to <code>index.js
 console.log('deleteResult', deleteResult)
 ```
 
+Then from the terminal, run:
+
+```bash
+node index.js
+```
+
 The output will resemble:
 
 ```


### PR DESCRIPTION
- removed reference to src folder from Quickstart
- added run command to a few steps that were missing it
- corrected link to Query guide
- addresses issue #606