### PR TITLE
Added globalThis polyfill

### DIFF
--- a/site/docs/web5/_quickstart-02-prereqs-and-installation.mdx
+++ b/site/docs/web5/_quickstart-02-prereqs-and-installation.mdx
@@ -67,6 +67,11 @@ import { Web5 } from '@tbd54566975/web5';
 Needs globalThis.crypto polyfill. This is *not* the crypto you're thinking of, it's the original crypto...CRYPTOGRAPHY.
 */
 import { webcrypto } from "node:crypto";
+
+if (!globalThis.crypto) {
+	globalThis.crypto = webcrypto;
+}
+
 ```
 </details>
 

--- a/site/docs/web5/_quickstart-02-prereqs-and-installation.mdx
+++ b/site/docs/web5/_quickstart-02-prereqs-and-installation.mdx
@@ -68,6 +68,7 @@ Needs globalThis.crypto polyfill. This is *not* the crypto you're thinking of, i
 */
 import { webcrypto } from "node:crypto";
 
+// @ts-ignore
 if (!globalThis.crypto) {
 	globalThis.crypto = webcrypto;
 }


### PR DESCRIPTION
The comments in the "Additional import for Node 18" section mentions using globalThis polyfill for the crypto object. But leaves out the code. This PR adds that code in to remove a speedbump for people who don't know how to create the polyfill.

I figured it went best here rather than in the main code sample.