### PR TITLE
Update todo-app-tutorial to use consistent package manager.mdx

### DIFF
--- a/site/docs/web5/build/apps/todo-app-tutorial.mdx
+++ b/site/docs/web5/build/apps/todo-app-tutorial.mdx
@@ -49,8 +49,8 @@ Add `Web5` to package.json in the `dependencies` section:
 Download the necessary packages by running these commands:
 
 ```bash
-npm install
-npm run dev
+pnpm install
+pnpm run dev
 ```
 
 You should now have the app running on [`https://localhost:5173`](https://localhost:5173/); this will be a starter application with a mostly blank page. In this tutorial, we'll build the rest.


### PR DESCRIPTION
Hey there! As I was running through the tutorial, I noticed that it started off suggesting that the user installs `pnpm`, but further down in Setup, we're referencing `npm`.  Thinking it might be best to stick to one package manager for the sake of consistency.