### PR TITLE
update link to docs folder

### DIFF
--- a/site/src/components/FeedbackWidget.jsx
+++ b/site/src/components/FeedbackWidget.jsx
@@ -19,7 +19,7 @@ function FeedbackWidget() {
         </p>
         <p>
           Edit this page:{' '}
-          <a href="https://github.com/TBD54566975/developer.tbd.website/tree/main/docs">
+          <a href="https://github.com/TBD54566975/developer.tbd.website/tree/main/site/docs">
             GitHub Repo
           </a>
         </p>


### PR DESCRIPTION
Hey @dayhaysoos, @angiejones ! This PR is a follow-up on [this issue](https://github.com/TBD54566975/developer.tbd.website/issues/301). So, after exploring the Docusaurus docs, I'm not sure using the `editUrl` [config field](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#editUrl) is going to work without some rethinking of the UI. According to the docs, configuring the field will automatically add the "Edit this page" link you see on most Docusaurus sites. See below: 
<img width="806" alt="Screenshot 2023-07-28 at 11 02 27 PM" src="https://github.com/TBD54566975/developer.tbd.website/assets/1965272/d0848044-d6fb-4278-aa16-a743fbeaa594">

<img width="1117" alt="Screenshot 2023-07-28 at 10 57 37 PM" src="https://github.com/TBD54566975/developer.tbd.website/assets/1965272/1610ef35-ae83-44db-a09d-43eae681e1ed">

Given that the TBD site has a custom Feedback Widget that contains the "Edit this page" link, I don't think this would play nice with the current designs.

Might need to think on this further, but in the meantime, I tweaked the URL to at least take you to the docs folder in GitHub instead of hitting the 404. Let me know what you think.
