### PR TITLE
Add `published` attributes to protocol definitions.

### DIFF
--- a/site/api/web5-js/dwn/protocols.mdx
+++ b/site/api/web5-js/dwn/protocols.mdx
@@ -159,7 +159,7 @@ const { protocol } = await web5.dwn.protocols.configure({
   message: {
     definition: {
       protocol: "https://photos.org/protocol",
-      publish: true,
+      published: true,
       types: {
         album: {
           schema: "https://photos.org/protocol/album",

--- a/site/api/web5-js/dwn/protocols.mdx
+++ b/site/api/web5-js/dwn/protocols.mdx
@@ -72,11 +72,11 @@ Configures a protocol definition in the user's local DWN, remote DWN, or another
                                                                     field: 'dataFormats',
                                                                     value: 'Array of the IANA strings corresponding with the formats of how the data will be bucketed. See IANA\'s Media Type list here: https://www.iana.org/assignments/media-types/media-types.xhtml',
                                                                 },
-                                                            },                              
+                                                            },
                                                         ]}
                                                       />,
                                                 },
-                                            }, 
+                                            },
                                             {
                                                 data: {
                                                     isObject: true,
@@ -105,26 +105,26 @@ Configures a protocol definition in the user's local DWN, remote DWN, or another
                                                                                 field: 'of',
                                                                                 value: 'The protocol path that refers to the record subject',
                                                                               },
-                                                                            }, 
+                                                                            },
                                                                             {
                                                                               data: {
                                                                                 type: 'string',
                                                                                 field: 'can',
                                                                                 value: 'The action being permitted by the rule',
                                                                               }
-                                                                            },                             
+                                                                            },
                                                                         ]}
                                                                       />,
                                                                 },
-                                                            },                              
+                                                            },
                                                         ]}
                                                       />,
                                                 },
-                                            },                                                             
+                                            },
                                         ]}
                                       />,
                                 },
-                            },                                            
+                            },
                         ]}
                       />,
                   },
@@ -159,6 +159,7 @@ const { protocol } = await web5.dwn.protocols.configure({
   message: {
     definition: {
       protocol: "https://photos.org/protocol",
+      publish: true,
       types: {
         album: {
           schema: "https://photos.org/protocol/album",
@@ -204,10 +205,10 @@ const { protocol } = await web5.dwn.protocols.configure({
 });
 
 /*
-Sends the protocol configuration to the user's remote DWNs. This function only needs 
+Sends the protocol configuration to the user's remote DWNs. This function only needs
 to be called if you'd like to send instantly and cannot wait for sync to occur.
 */
-protocol.send(myDid); 
+protocol.send(myDid);
 ```
 
 
@@ -252,7 +253,7 @@ Queries a DID's DWNs for the presence of a protocol. This method is useful in de
                                         field: 'dateCreated',
                                         value: 'Date of creation for the protocols to query',
                                     }
-                                },                           
+                                },
                                 {
                                     data: {
                                         isObject: true,
@@ -268,15 +269,15 @@ Queries a DID's DWNs for the presence of a protocol. This method is useful in de
                                                         field: 'protocol',
                                                         value: 'URI of the protocol bucket in which to query',
                                                     },
-                                                },  
+                                                },
                                             ]}
                                         />,
                                     },
-                                },                            
+                                },
                             ]}
                         />,
                     },
-                },                                             
+                },
             ]}
           />,
       },

--- a/site/api/web5-js/dwn/protocols.mdx
+++ b/site/api/web5-js/dwn/protocols.mdx
@@ -54,7 +54,7 @@ Configures a protocol definition in the user's local DWN, remote DWN, or another
                                                 data: {
                                                     type: 'boolean',
                                                     field: 'published',
-                                                    value: 'Specifies whether the protocol appears in the results of protocols.query()',
+                                                    value: 'Indicates whether the protocol should be public',
                                                 },
                                             },
                                             {

--- a/site/api/web5-js/dwn/protocols.mdx
+++ b/site/api/web5-js/dwn/protocols.mdx
@@ -52,6 +52,13 @@ Configures a protocol definition in the user's local DWN, remote DWN, or another
                                             },
                                             {
                                                 data: {
+                                                    type: 'boolean',
+                                                    field: 'published',
+                                                    value: 'Specifies whether the protocol appears in the results of protocols.query()',
+                                                },
+                                            },
+                                            {
+                                                data: {
                                                     isObject: true,
                                                     type: 'ProtocolTypes',
                                                     field: 'types',

--- a/site/docs/web5/learn/protocols.md
+++ b/site/docs/web5/learn/protocols.md
@@ -33,6 +33,7 @@ We know the key words for defining protocols - `types`, `structure`, and `action
 ```json
 {
   "protocol": "https://social-media.xyz",
+  "published": true,
   "types": {
     "message": {
       "schema": "https://social-media.xyz/schemas/messageSchema",
@@ -285,12 +286,12 @@ To use a protocol in your app, you’ll need to install that protocol to your DW
 ```js
 const { protocol, status } = await web5.dwn.protocols.configure({
     message: {
-      definition: protocolDefinition 
+      definition: protocolDefinition
     }
 });
 
 //sends protocol to remote DWNs immediately (vs waiting for sync)
-await protocol.send(myDid); 
+await protocol.send(myDid);
 ```
 
 Once you’ve installed that protocol to your app, you’re ready to communicate using the schema and permissions it defines.

--- a/site/docs/web5/learn/protocols.md
+++ b/site/docs/web5/learn/protocols.md
@@ -12,6 +12,7 @@ Protocols are written in a JSON format that is flexible enough to detail what ob
 
 Every protocol document has a few basic keys:
 
+- `published` - Determines whether the protocol appears in the results of `protocols.query`
 - `types` - Defines all the data types used in your document
 - `structure` - Defines a list of properties
 - `$actions` - The key word used to denote the start of a permission definition
@@ -28,7 +29,7 @@ Now let’s imagine how we’d construct the permissions for such an app. We wan
 
 ## Defining a Protocol
 
-We know the key words for defining protocols - `types`, `structure`, and `actions` - as well as our data and permissions schemas. So our protocol would look this:
+We know the key words for defining protocols - `published`, `types`, `structure`, and `actions` - as well as our data and permissions schemas. So our protocol would look this:
 
 ```json
 {
@@ -110,6 +111,15 @@ We know the key words for defining protocols - `types`, `structure`, and `action
       }
     }
   }
+}
+```
+With the `published` attribute, protocols can be set to appear in the results of a `protocol.query` method. All matching protocols are returned when a tenant calls `protocols.query` but when called by someone else, only published protocols are returned.
+
+```json
+{
+  "protocol": "https://social-media.xyz",
+  "published": true,
+  ...
 }
 ```
 

--- a/site/docs/web5/learn/protocols.md
+++ b/site/docs/web5/learn/protocols.md
@@ -12,7 +12,6 @@ Protocols are written in a JSON format that is flexible enough to detail what ob
 
 Every protocol document has a few basic keys:
 
-- `published` - Determines whether the protocol appears in the results of `protocols.query`
 - `types` - Defines all the data types used in your document
 - `structure` - Defines a list of properties
 - `$actions` - The key word used to denote the start of a permission definition
@@ -29,7 +28,7 @@ Now let’s imagine how we’d construct the permissions for such an app. We wan
 
 ## Defining a Protocol
 
-We know the key words for defining protocols - `published`, `types`, `structure`, and `actions` - as well as our data and permissions schemas. So our protocol would look this:
+We know the key words for defining protocols - `types`, `structure`, and `actions` - as well as our data and permissions schemas. So our protocol would look this:
 
 ```json
 {
@@ -113,7 +112,10 @@ We know the key words for defining protocols - `published`, `types`, `structure`
   }
 }
 ```
-With the `published` attribute, protocols can be set to appear in the results of a `protocol.query` method. All matching protocols are returned when a tenant calls `protocols.query` but when called by someone else, only published protocols are returned.
+
+The value for `protocol` is a URI that represents the protocol being configured.
+
+The `published` attribute indicates whether the protocol should be public. Published protocols are accessible by anyone who [queries](/api/web5-js/dwn/protocols#queryrequest) for them.
 
 ```json
 {


### PR DESCRIPTION
Pending getting more information on what the new attribute implies in order to add the description to the doc, I have added the `published` attribute to the example definitions. 