### PR TITLE
Add FEEDBACK_WIDGET_API_URL env and some refactors

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'site/**'
   - 'examples/**'
+  - 'apps/**'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
 packages:
   - 'site/**'
   - 'examples/**'
-  - 'apps/**'

--- a/site/.env.example
+++ b/site/.env.example
@@ -1,0 +1,7 @@
+# Algolia Config
+#DOC_SEARCH_API_KEY=<api_key>
+#DOC_SEARCH_INDEX_NAME=<index_name>
+#DOC_SEARCH_APP_ID=<app_id>
+
+# Feedback Widget
+#FEEDBACK_WIDGET_API_URL=https://tbd-feedback-spreadsheet-server.vercel.app/api

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -10,6 +10,8 @@ const algoliaApiKey = process.env.DOC_SEARCH_API_KEY;
 const algoliaIndexName = process.env.DOC_SEARCH_INDEX_NAME;
 const algoliaAppId = process.env.DOC_SEARCH_APP_ID;
 
+const feedbackWidgetApiUrl = process.env.FEEDBACK_WIDGET_API_URL;
+
 let algoliaConfig = null;
 if (algoliaApiKey && algoliaIndexName && algoliaAppId) {
   algoliaConfig = {
@@ -41,6 +43,7 @@ let config = {
   // },
   customFields: {
     WEB5_VERSION,
+    feedbackWidgetApiUrl,
   },
   plugins: [
     'docusaurus-tailwindcss',

--- a/site/src/components/FeedbackWidget.jsx
+++ b/site/src/components/FeedbackWidget.jsx
@@ -1,79 +1,16 @@
-import React, { useState, useEffect } from 'react';
-import Card from './Card';
+import React from 'react';
 import Link from '@docusaurus/Link';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faThumbsUp, faThumbsDown } from '@fortawesome/free-solid-svg-icons';
 
+import Card from './Card';
+import FeedbackWidgetRating from './FeedbackWidgetRating';
 import '../css/feedback.css';
 
-function RatingButton({ label, icon, onClick }) {
-  return (
-    <div className="rating-box" onClick={onClick}>
-      {label}
-      <FontAwesomeIcon icon={icon} className="icon" />
-    </div>
-  );
-}
-
 function FeedbackWidget() {
-  const [userFeedback, setUserFeedback] = useState(null);
-  const [csrfToken, setCsrfToken] = useState('');
-
-  useEffect(() => {
-    fetch('https://tbd-feedback-spreadsheet-server.vercel.app/api/csrf-token', { 
-      credentials: 'include'
-    })
-      .then(res => res.json())
-      .then(data => setCsrfToken(data.csrfToken));
-  }, []);
-
-  const handleUserRatingClick = (rating) => {
-    setUserFeedback(rating);
-    const requestBody = {
-      rating: rating === 'like' ? 'helpful' : 'notHelpful',
-      pageLink: window.location.href,
-    };
-    console.log('Sending request:', requestBody);
-    fetch('https://tbd-feedback-spreadsheet-server.vercel.app/api/feedback', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-csrf-token': csrfToken
-      },
-      credentials: 'include',
-      body: JSON.stringify(requestBody),
-    });
-  };
-
   return (
     <div className="flex justify-end lg:mt-8">
       <Card className="w-full">
         <h3 className="text-3xl feedback-header">Was this page helpful?</h3>
-        <div className="rating">
-          {userFeedback ? (
-            <>
-              <span>Thank you for your feedback!</span>
-              <FontAwesomeIcon
-                icon={userFeedback === 'like' ? faThumbsUp : faThumbsDown}
-                className={userFeedback ? 'active-icon' : 'icon'}
-              />
-            </>
-          ) : (
-            <>
-              <RatingButton
-                label="Helpful"
-                icon={faThumbsUp}
-                onClick={() => handleUserRatingClick('like')}
-              />
-              <RatingButton
-                label="Not Helpful"
-                icon={faThumbsDown}
-                onClick={() => handleUserRatingClick('dislike')}
-              />
-            </>
-          )}
-        </div>
-
+        <FeedbackWidgetRating />
         <p>
           Connect with us on{' '}
           <a href="https://discord.com/invite/tbd">Discord</a>

--- a/site/src/components/FeedbackWidgetRating.jsx
+++ b/site/src/components/FeedbackWidgetRating.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faThumbsUp, faThumbsDown } from '@fortawesome/free-solid-svg-icons';
+
+import '../css/feedback.css';
+import { useFeedbackRating } from '../hooks';
+
+function FeedbackWidgetRating() {
+  const { isFeedbackRatingEnabled, userFeedback, submitUserRating } =
+    useFeedbackRating();
+
+  return isFeedbackRatingEnabled ? (
+    <div className="rating">
+      {userFeedback ? (
+        <>
+          <span>Thank you for your feedback!</span>
+          <FontAwesomeIcon
+            icon={userFeedback === 'like' ? faThumbsUp : faThumbsDown}
+            className={userFeedback ? 'active-icon' : 'icon'}
+          />
+        </>
+      ) : (
+        <>
+          <RatingButton
+            label="Helpful"
+            icon={faThumbsUp}
+            onClick={() => submitUserRating('like')}
+          />
+          <RatingButton
+            label="Not Helpful"
+            icon={faThumbsDown}
+            onClick={() => submitUserRating('dislike')}
+          />
+        </>
+      )}
+    </div>
+  ) : null;
+}
+
+function RatingButton({ label, icon, onClick }) {
+  return (
+    <div className="rating-box" onClick={onClick}>
+      {label}
+      <FontAwesomeIcon icon={icon} className="icon" />
+    </div>
+  );
+}
+
+export default FeedbackWidgetRating;

--- a/site/src/hooks/index.js
+++ b/site/src/hooks/index.js
@@ -1,0 +1,1 @@
+export * from './use-feedback-rating';

--- a/site/src/hooks/use-feedback-rating.js
+++ b/site/src/hooks/use-feedback-rating.js
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export const useFeedbackRating = () => {
+  const [userFeedback, setUserFeedback] = useState('');
+  const [csrfToken, setCsrfToken] = useState('');
+
+  const {
+    siteConfig: { customFields },
+  } = useDocusaurusContext();
+
+  const feedbackWidgetUrl = customFields.feedbackWidgetApiUrl;
+  const isFeedbackRatingEnabled = feedbackWidgetUrl && csrfToken;
+
+  useEffect(() => {
+    if (feedbackWidgetUrl) {
+      getFeedbackCsrfToken(feedbackWidgetUrl)
+        .then(setCsrfToken)
+        .catch(console.error);
+    }
+  }, []);
+
+  const submitUserRating = async (rating) => {
+    if (!csrfToken) {
+      throw new Error("Can't send feedback without CSRF token");
+    }
+
+    // TODO: we need to handle cases where the rating request fails
+    setUserFeedback(rating);
+
+    await postFeedbackRating(feedbackWidgetUrl, csrfToken, rating);
+  };
+
+  return {
+    isFeedbackRatingEnabled,
+    userFeedback,
+    submitUserRating,
+  };
+};
+
+const getFeedbackCsrfToken = async (feedbackWidgetUrl) => {
+  const res = await fetch(`${feedbackWidgetUrl}/csrf-token`, {
+    credentials: 'include',
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch feedback widget CSRF token: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  const data = await res.json();
+  return data.csrfToken;
+};
+
+const postFeedbackRating = async (feedbackWidgetUrl, csrfToken, rating) => {
+  const requestBody = {
+    rating: rating === 'like' ? 'helpful' : 'notHelpful',
+    pageLink: window.location.href,
+  };
+  console.info('Sending request:', requestBody);
+
+  fetch(`${feedbackWidgetUrl}/feedback`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-csrf-token': csrfToken,
+    },
+    credentials: 'include',
+    body: JSON.stringify(requestBody),
+  });
+};


### PR DESCRIPTION
Continuing the work from #702 and #714 ... 

- Introduced the `FEEDBACK_WIDGET_API_URL`
  - When it's not present we don't render the user rating component
- Added some refactoring to make the components (S)OLID
- Extracted the view + API functions logic to a proper hook `useFeedbackRating`