### PR TITLE
Remove console statement and add retry logic for FeedbackWidget 

### DIFF
--- a/site/src/hooks/use-feedback-rating.js
+++ b/site/src/hooks/use-feedback-rating.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { wait } from '../util/feedback-retry-wait';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 export const useFeedbackRating = () => {
@@ -25,8 +26,6 @@ export const useFeedbackRating = () => {
     setCsrfToken(freshToken);
     return freshToken;
   };
-
-  const wait = (duration) => new Promise(resolve => setTimeout(resolve, duration));
 
   const submitUserRating = async (rating, maxTries = 3) => {
     let currentToken = csrfToken;

--- a/site/src/hooks/use-feedback-rating.js
+++ b/site/src/hooks/use-feedback-rating.js
@@ -95,4 +95,5 @@ const postFeedbackRating = async (feedbackWidgetUrl, csrfToken, rating) => {
 
   if (!res.ok) {
     throw new Error('Failed to submit feedback rating');
-  }
+  } 
+};

--- a/site/src/hooks/use-feedback-rating.js
+++ b/site/src/hooks/use-feedback-rating.js
@@ -58,7 +58,6 @@ const postFeedbackRating = async (feedbackWidgetUrl, csrfToken, rating) => {
     rating: rating === 'like' ? 'helpful' : 'notHelpful',
     pageLink: window.location.href,
   };
-  console.info('Sending request:', requestBody);
 
   fetch(`${feedbackWidgetUrl}/feedback`, {
     method: 'POST',

--- a/site/src/hooks/use-feedback-rating.js
+++ b/site/src/hooks/use-feedback-rating.js
@@ -83,7 +83,7 @@ const postFeedbackRating = async (feedbackWidgetUrl, csrfToken, rating) => {
     pageLink: window.location.href,
   };
 
-  fetch(`${feedbackWidgetUrl}/feedback`, {
+  const res = await fetch(`${feedbackWidgetUrl}/feedback`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -92,4 +92,7 @@ const postFeedbackRating = async (feedbackWidgetUrl, csrfToken, rating) => {
     credentials: 'include',
     body: JSON.stringify(requestBody),
   });
-};
+
+  if (!res.ok) {
+    throw new Error('Failed to submit feedback rating');
+  }

--- a/site/src/hooks/use-feedback-rating.js
+++ b/site/src/hooks/use-feedback-rating.js
@@ -20,6 +20,8 @@ export const useFeedbackRating = () => {
     }
   }, []);
 
+  const wait = (duration) => new Promise(resolve => setTimeout(resolve, duration));
+
   const submitUserRating = async (rating, maxTries = 3) => {
     if (!csrfToken) {
       throw new Error("Can't send feedback without CSRF token");
@@ -37,7 +39,7 @@ export const useFeedbackRating = () => {
         
         if (currentTry < maxTries) {
           const waitTime = currentTry * 1000;
-          await new Promise(resolve => setTimeout(resolve, waitTime));
+          await wait(waitTime);
         }
       }
     }

--- a/site/src/util/feedback-retry-wait.js
+++ b/site/src/util/feedback-retry-wait.js
@@ -1,0 +1,1 @@
+export const wait = (duration) => new Promise(resolve => setTimeout(resolve, duration));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] ♻️ Refactor
- [x] ✨ New Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 👷 Example Application
- [ ] 🧑‍💻 Code Snippet
- [ ] 🎨 Design
- [ ] 📖 Content
- [ ] 🧪 Tests
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

### First Commit
This PR removes the not needed `console.info` statement which appears in the console when a rating is clicked.

#### Second Commit
In case of a failure in feedback submission due to any reason like network unreliability, added a retry mechanism which will attempt to resubmit the feedback up to three times before throwing an error in the console if it keeps failing. 


