### PR TITLE
updating next config to handle node crypto errors

### DIFF
--- a/examples/tutorials/dinger-completed/next.config.js
+++ b/examples/tutorials/dinger-completed/next.config.js
@@ -1,6 +1,31 @@
+const webpack = require('webpack');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
 
-module.exports = nextConfig
+  webpack: (config, { isServer, buildId, dev, webpack }) => {
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        stream: require.resolve('stream-browserify'),
+        crypto: require.resolve('crypto-browserify'),
+      };
+
+      config.plugins.push(
+        new webpack.ProvidePlugin({
+          process: 'process/browser',
+        }),
+        new webpack.NormalModuleReplacementPlugin(
+          /node:crypto/,
+          (resource) => {
+            resource.request = resource.request.replace(/^node:/, '');
+          }
+        )
+      );
+    }
+    return config;
+  },
+};
+
+module.exports = nextConfig;

--- a/examples/tutorials/dinger-completed/package.json
+++ b/examples/tutorials/dinger-completed/package.json
@@ -10,8 +10,11 @@
   },
   "dependencies": {
     "@web5/api": "0.8.2-alpha-20231109-019e92e",
+    "crypto-browserify": "3.12.0",
     "next": "13.5.4",
+    "process": "^0.11.10",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "stream-browserify": "3.0.0"
   }
 }

--- a/examples/tutorials/dinger-starter/next.config.js
+++ b/examples/tutorials/dinger-starter/next.config.js
@@ -1,6 +1,31 @@
+const webpack = require('webpack');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
 
-module.exports = nextConfig
+  webpack: (config, { isServer, buildId, dev, webpack }) => {
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        stream: require.resolve('stream-browserify'),
+        crypto: require.resolve('crypto-browserify'),
+      };
+
+      config.plugins.push(
+        new webpack.ProvidePlugin({
+          process: 'process/browser',
+        }),
+        new webpack.NormalModuleReplacementPlugin(
+          /node:crypto/,
+          (resource) => {
+            resource.request = resource.request.replace(/^node:/, '');
+          }
+        )
+      );
+    }
+    return config;
+  },
+};
+
+module.exports = nextConfig;

--- a/examples/tutorials/dinger-starter/package.json
+++ b/examples/tutorials/dinger-starter/package.json
@@ -10,8 +10,11 @@
   },
   "dependencies": {
     "@web5/api": "0.8.2-alpha-20231109-019e92e",
+    "crypto-browserify": "3.12.0",
     "next": "13.5.4",
+    "process": "^0.11.10",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "stream-browserify": "3.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,30 +109,48 @@ importers:
       '@web5/api':
         specifier: 0.8.2-alpha-20231109-019e92e
         version: 0.8.2-alpha-20231109-019e92e
+      crypto-browserify:
+        specifier: 3.12.0
+        version: 3.12.0
       next:
         specifier: 13.5.4
         version: 13.5.4(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
+      process:
+        specifier: ^0.11.10
+        version: 0.11.10
       react:
         specifier: ^18
         version: 18.2.0
       react-dom:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
+      stream-browserify:
+        specifier: 3.0.0
+        version: 3.0.0
 
   examples/tutorials/dinger-starter:
     dependencies:
       '@web5/api':
         specifier: 0.8.2-alpha-20231109-019e92e
         version: 0.8.2-alpha-20231109-019e92e
+      crypto-browserify:
+        specifier: 3.12.0
+        version: 3.12.0
       next:
         specifier: 13.5.4
         version: 13.5.4(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
+      process:
+        specifier: ^0.11.10
+        version: 0.11.10
       react:
         specifier: ^18
         version: 18.2.0
       react-dom:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
+      stream-browserify:
+        specifier: 3.0.0
+        version: 3.0.0
 
   examples/tutorials/shared-todo-completed:
     dependencies:


### PR DESCRIPTION
- Modified my example app's next.config.js to include a custom Webpack configuration.
- Added fallbacks for stream and crypto to use browser-compatible versions provided by stream-browserify and crypto-browserify.