### PR TITLE
increasing font size of h3 doc headers

### DIFF
--- a/site/src/css/docs.css
+++ b/site/src/css/docs.css
@@ -818,3 +818,7 @@ html.plugin-docs.plugin-id-default article .theme-card p {
 .tbd-blue-illustration {
   filter: var(--color-primary-cyan-filter);
 }
+
+.markdown > h3 {
+  font-size: 1.5rem;
+}


### PR DESCRIPTION
<h3> elements in docs are too small (1rem). they are smaller than the text under them. fixing that 