### PR TITLE
move Message Types guide

### DIFF
--- a/site/docs/tbdex/message-types.mdx
+++ b/site/docs/tbdex/message-types.mdx
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # Message Types
 
-PFIs are able to communicate with Wallets by using the following tbDEX message types:
+PFIs and Wallets are able to communicate with each other by using the following tbDEX message types:
 
 * [**RFQ**](/docs/tbdex/api-reference/tbdex-js/protocol/classes/Rfq) - A message sent by a wallet to a PFI requesting a quote for an ask
 
@@ -16,4 +16,5 @@ PFIs are able to communicate with Wallets by using the following tbDEX message t
 
 * [**Close**](/docs/tbdex/pfi/processing-orders#close-the-order) - A message sent by a wallet or a PFI in response to an RFQ or Quote
 
-Additionally as a PFI, you'll offer a list of [Offerings](/docs/tbdex/pfi/creating-offerings), which is represented by a resource used to describe a currency pair that can be exchanged and includes requirements, conditions, and constraints needed to fulfill the described swap. 
+Additionally PFIs offer a list of [Offerings](/docs/tbdex/pfi/creating-offerings), which is represented by a resource used to describe a currency pair that can be exchanged and includes requirements, conditions, and constraints needed to fulfill the described swap. 
+Wallets can fetch a PFI's list of Offerings and present them to their users.

--- a/site/docs/tbdex/pfi/_category_.json
+++ b/site/docs/tbdex/pfi/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "PFIs",
-  "position": 1
+  "position": 3
 }

--- a/site/docs/tbdex/pfi/anatomy-of-a-pfi.mdx
+++ b/site/docs/tbdex/pfi/anatomy-of-a-pfi.mdx
@@ -28,7 +28,7 @@ const httpApi = new TbdexHttpServer({ exchangesApi: ExchangeApiProvider, offerin
 ```
 
 
-The [message types](/docs/tbdex/pfi/message-types) that are sent from Wallets to PFIs are: `RFQ`, `Order`, and `Close`. 
+The [message types](/docs/tbdex/message-types) that are sent from Wallets to PFIs are: `RFQ`, `Order`, and `Close`. 
 As a result, you’ll want to ensure that your PFI is programmed to accept those messages and create appropriate messages in response:
 
 

--- a/site/docs/tbdex/pfi/overview.mdx
+++ b/site/docs/tbdex/pfi/overview.mdx
@@ -14,7 +14,7 @@ The PFI guides are intended to provide you with what you need to begin participa
 
 ## Recommended Path
 
-1. [Review Message Types](/docs/tbdex/pfi/message-types)
+1. [Review Message Types](/docs/tbdex/message-types)
 2. [Install Required SDKs](/docs/tbdex/pfi/required-sdks)
 3. [Onboard as a PFI](/docs/tbdex/pfi/onboarding)
 4. [Review Anatomy of a PFI](/docs/tbdex/pfi/anatomy-of-a-pfi)

--- a/site/docs/tbdex/wallet/_category_.json
+++ b/site/docs/tbdex/wallet/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Wallets",
+  "position": 4
+}


### PR DESCRIPTION
Message Types apply to both PFIs and Wallets, so instead of duplicating the guide in both sections, I've moved it to right under tbDEX

<img width="277" alt="image" src="https://github.com/TBD54566975/developer.tbd.website/assets/15972783/9f271171-f7d0-4035-9587-1f6c14f4f09f">