### PR TITLE
Reroute Troubleshooting Guide dead link to new link

### DIFF
--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -12,4 +12,8 @@ to = "/files/Decentralized-Web-Platform.pdf"
 
 [[redirects]]
 from = "/docs/web5/build/troubleshooting-guide"
-to = "/docs/web5/troubleshooting-guide"
+to = "/docs/web5/troubleshooting/common-errors"
+
+[[redirects]]
+from = "/docs/web5/troubleshooting-guide"
+to = "/docs/web5/troubleshooting/common-errors"


### PR DESCRIPTION
when moving links, always remember to add a reroute here so that the URLs in Discord don't 404. 
cc @acekyd @blackgirlbytes @EbonyLouis 