### PR TITLE
Added /browser to import for troubleshooting

### DIFF
--- a/site/docs/web5/troubleshooting/common-errors.mdx
+++ b/site/docs/web5/troubleshooting/common-errors.mdx
@@ -52,7 +52,7 @@ module.exports = nextConfig;
 When starting up and connecting to the Web5 SDK, some polyfills might be missing. To fix this, update your Web5 import:
 
 ```js
-import { Web5 } from '@web5/api';
+import { Web5 } from '@web5/api/browser';
 ```
 
 ## ProtocolAuthorizationIncorrectProtocolPath: Declared protocol path 'x' is not the same as actual protocol path 'y/x'


### PR DESCRIPTION
Troubleshooting guide omitted the /browser on the import

<img width="859" alt="image" src="https://github.com/TBD54566975/developer.tbd.website/assets/15972783/f7917a99-64c7-4cf0-9210-8e44525b54f3">