### PR TITLE
Removed tbDEX->API Ref from sidebar

### DIFF
--- a/site/docs/tbdex/api_ref.mdx
+++ b/site/docs/tbdex/api_ref.mdx
@@ -1,8 +1,0 @@
----
-sidebar_position: 1
-title: API Reference
----
-
-Redirecting... if you're still reading this [click here](https://tbd54566975.github.io/tbdex-js/index.html)
-
-<meta http-equiv="refresh" content="0; URL='https://tbd54566975.github.io/tbdex-js/index.html'" />


### PR DESCRIPTION
Removed tbDEX-> API Reference Guide from sidebar since it pointed to the JS version. We're now using the API Reference Guides sidebar item to show a page with multiple SDKs