### PR TITLE
enhancing inline code snippets

### DIFF
--- a/site/src/components/language/Shnip.jsx
+++ b/site/src/components/language/Shnip.jsx
@@ -5,27 +5,51 @@ import CodeSnippet from '@site/src/components/CodeSnippet';
 import CodeBlock from '@theme/CodeBlock';
 
 const Shnip = ({ snippets, inlineSnippets }) => {
+  // support line breaks for inline code snippets
+  const addLineBreaks = (code, breakLines) => {
+    if (!breakLines || breakLines.length === 0) {
+      return code;
+    }
+
+    const lines = code.split('\n');
+    breakLines.forEach((lineNumber) => {
+      if (lineNumber < lines.length) {
+        lines[lineNumber] += '\n';
+      }
+    });
+
+    return lines.join('\n');
+  };
+
   return (
     <>
       <LanguageTabBar />
       <LanguageSwitchBlock>
-        {snippets && snippets.map(({ snippetContent, language }) => (
-          <div key={`ref-${language}`} language={language}>
-            <CodeSnippet
-              snippet={snippetContent}
-              language={language.toLowerCase()}
-            />
-          </div>
-        ))}
-
-        {inlineSnippets &&
-          inlineSnippets.map(({ code, language }) => (
-            <div key={`inline-${language}`} language={language}>
-              <CodeBlock language={language.toLowerCase()}>
-                {code.trim()}
-              </CodeBlock>
+        {snippets &&
+          snippets.map(({ snippetContent, language, title }) => (
+            <div key={`ref-${language}`} language={language}>
+              <CodeSnippet
+                snippet={snippetContent}
+                language={language.toLowerCase()}
+                title={title}
+              />
             </div>
           ))}
+
+        {inlineSnippets &&
+          inlineSnippets.map(
+            ({ code, language, codeLanguage, title, breakLineAt }) => (
+              <div key={`inline-${language}`} language={language}>
+                <CodeBlock
+                  // parse as specified language such as bash OR parse as language from tab
+                  language={(codeLanguage || language).toLowerCase()}
+                  title={title}
+                >
+                  {addLineBreaks(code, breakLineAt)}
+                </CodeBlock>
+              </div>
+            ),
+          )}
       </LanguageSwitchBlock>
     </>
   );

--- a/site/src/pages/open-source/contributing.mdx
+++ b/site/src/pages/open-source/contributing.mdx
@@ -109,6 +109,69 @@ This is how you can add a generated code snippet and an inline hardcoded snippet
 />
 ```
 
+To display inline code in a language different from the tab's primary language, use `codeLanguage`. 
+If `codeLanguage` is unspecified, it defaults to `language`. 
+Example: For Bash in a JavaScript tab, set `language: 'JavaScript`', `codeLanguage: 'bash'`
+
+```js
+<Shnip
+  inlineSnippets={[
+    {
+      code: `
+npm install @web5/credentials
+npm install @web5/dids
+      `,
+      language: 'JavaScript', // The tab's context.
+      codeLanguage: 'bash', // Snippet's actual language
+    }
+  ]}
+/>
+```
+
+MDX and JSX struggle to parse line breaks.
+For controlled line breaks in inline snippets, use `breakLineAt` with line numbers in an array.
+Example: To break after lines 1 and 5, set breakLineAt: [1, 5]
+<Shnip
+  inlineSnippets={[
+    {
+      code: `
+import { VerifiableCredential, PresentationExchange } from "@web5/credentials";
+class SwiftiesFanClub {
+  constructor(level, legit) {
+    // indicates the fan's dedication level
+    this.level = level; 
+    // indicates if the fan is a genuine Swiftie
+    this.legit = legit; 
+  }
+}
+      `,
+      breakLineAt:[1, 5]
+    }
+  ]}
+/>
+
+To add titles to code snippets, use the title prop. Example: title: 'Issuer.js' adds a title to the snippet.
+<Shnip
+ snippets={[{ name: 'assignVcJwt', language: 'JavaScript', title: 'Issuer.js' }]}
+  inlineSnippets={[
+    {
+      code: `
+import { VerifiableCredential, PresentationExchange } from "@web5/credentials";
+class SwiftiesFanClub {
+  constructor(level, legit) {
+    // indicates the fan's dedication level
+    this.level = level; 
+    // indicates if the fan is a genuine Swiftie
+    this.legit = legit; 
+  }
+}
+      `,
+     title: 'Issuer.js',
+    }
+  ]}
+/>
+
+
 ### Caveats for Code Snippets
 
 - The code snippet function names need to be unique, these names are what is used to generate/name the snippet files.

--- a/site/src/pages/open-source/contributing.mdx
+++ b/site/src/pages/open-source/contributing.mdx
@@ -131,6 +131,8 @@ npm install @web5/dids
 MDX and JSX struggle to parse line breaks.
 For controlled line breaks in inline snippets, use `breakLineAt` with line numbers in an array.
 Example: To break after lines 1 and 5, set breakLineAt: [1, 5]
+
+```js
 <Shnip
   inlineSnippets={[
     {
@@ -149,8 +151,9 @@ class SwiftiesFanClub {
     }
   ]}
 />
-
+```
 To add titles to code snippets, use the title prop. Example: title: 'Issuer.js' adds a title to the snippet.
+```
 <Shnip
  snippets={[{ name: 'assignVcJwt', language: 'JavaScript', title: 'Issuer.js' }]}
   inlineSnippets={[
@@ -170,7 +173,7 @@ class SwiftiesFanClub {
     }
   ]}
 />
-
+```
 
 ### Caveats for Code Snippets
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ New Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 👷 Example Application
- [x] 🧑‍💻 Code Snippet
- [ ] 🎨 Design
- [ ] 📖 Content
- [ ] 🧪 Tests
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

<!-- Please do not leave this blank -->

This PR enhances the Shnip component and enables it to have the following:
###  Different language code snippet than what's specified in the tab. 
Here we are saying you're writing JavaScript, so we're assuming the code snippet is JS, but it's actually bash

<img width="919" alt="Screenshot 2024-02-01 at 12 54 10 PM" src="https://github.com/TBD54566975/developer.tbd.website/assets/22990146/1bc78fd1-7dae-490a-a1e7-2e2bc6674dc7">

But the new change enables this
<img width="1002" alt="Screenshot 2024-02-01 at 12 59 06 PM" src="https://github.com/TBD54566975/developer.tbd.website/assets/22990146/92ab1cf0-7e35-411a-8c9d-041b4eba067a">

### Line breaks
For inline code snippets, MDX would freak out if it saw a line break, so you had to do this
<img width="974" alt="Screenshot 2024-02-01 at 12 54 17 PM" src="https://github.com/TBD54566975/developer.tbd.website/assets/22990146/a24b9047-c877-4a86-8093-cca05db21fbc">

But now you can pass in the number at which you want to break the line at using `breakLineAt:[5]`
<img width="962" alt="Screenshot 2024-02-01 at 12 59 00 PM" src="https://github.com/TBD54566975/developer.tbd.website/assets/22990146/32148fc5-e5ae-4d84-9300-ba6f95ad1115">

## Titles
We couldn't specify titles of the files at first
<img width="997" alt="Screenshot 2024-02-01 at 2 24 58 PM" src="https://github.com/TBD54566975/developer.tbd.website/assets/22990146/decfe716-6401-45e1-986b-072d43f41986">
<img width="911" alt="Screenshot 2024-02-01 at 2 25 05 PM" src="https://github.com/TBD54566975/developer.tbd.website/assets/22990146/21ac7c0a-5675-4b0e-9662-0b6036011d0d">

but now we can
<img width="967" alt="Screenshot 2024-02-01 at 2 25 35 PM" src="https://github.com/TBD54566975/developer.tbd.website/assets/22990146/7bb02dcf-f8b6-4c5f-b21b-cb6913db1989">





Please review to make sure I didn't break any fundamental functionality that I might've missed. 