### PR TITLE
Issue #1197 - Add tbdex-kt dependencies

### DIFF
--- a/site/testsuites/testsuite-kotlin/pom.xml
+++ b/site/testsuites/testsuite-kotlin/pom.xml
@@ -209,11 +209,14 @@
             <name>jboss</name>
             <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
         </repository>
-      <repository>
-        <id>sonatype-oss-snapshots</id>
-        <name>sonatype-oss-snapshots</name>
-        <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-        <snapshots />
-      </repository>
+        <!--
+        More ALR Dark Arts, remove this once we are no longer relying on tbdex-kt:SNAPSHOTs
+        -->
+        <repository>
+            <id>sonatype-oss-snapshots</id>
+            <name>sonatype-oss-snapshots</name>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots />
+        </repository>
     </repositories>
 </project>

--- a/site/testsuites/testsuite-kotlin/pom.xml
+++ b/site/testsuites/testsuite-kotlin/pom.xml
@@ -25,12 +25,19 @@
         These need to be uniformly updated as part of the
         single dependency script from Nick
         -->
-        <version.tbdex>0.8.0-beta</version.tbdex>
-        <version.web5>0.10.0</version.web5>
+        <version.tbdex>0.9.0-SNAPSHOT</version.tbdex>
+
+        <!-- ALR Dark Arts to Make tbDEX and Web5 Play Nice -->
+        <!--
+        Will eventually go bye-bye once the
+        underlying dep trees are fixed up
+        -->
+        <version.com.fasterxml.jackson.core>2.9.8</version.com.fasterxml.jackson.core>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!-- External Dependencies -->
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
@@ -71,36 +78,21 @@
               <artifactId>tbdex-protocol</artifactId>
               <version>${version.tbdex}</version>
             </dependency>
+
+            <!-- ALR Dark Arts to Make tbDEX and Web5 Play Nice -->
+            <!--
+            Will eventually go bye-bye once the
+            underlying dep trees are fixed up
+            -->
             <dependency>
-                <groupId>xyz.block</groupId>
-                <artifactId>web5</artifactId>
-                <version>${version.web5}</version>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-core</artifactId>
+              <version>${version.com.fasterxml.jackson.core}</version>
             </dependency>
             <dependency>
-                <groupId>xyz.block</groupId>
-                <artifactId>web5-common</artifactId>
-                <version>${version.web5}</version>
-            </dependency>
-            <dependency>
-                <groupId>xyz.block</groupId>
-                <artifactId>web5-credentials</artifactId>
-                <version>${version.web5}</version>
-            </dependency>
-            <dependency>
-                <groupId>xyz.block</groupId>
-                <artifactId>web5-crypto</artifactId>
-                <version>${version.web5}</version>
-            </dependency>
-            <dependency>
-                <groupId>xyz.block</groupId>
-                <artifactId>web5-dids</artifactId>
-                <version>${version.web5}</version>
-            </dependency>
-            <dependency>
-                <groupId>xyz.block</groupId>
-                <artifactId>web5-testing</artifactId>
-                <version>${version.web5}</version>
-                <scope>test</scope>
+              <groupId>com.fasterxml.jackson.core</groupId>
+              <artifactId>jackson-databind</artifactId>
+              <version>${version.com.fasterxml.jackson.core}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -135,30 +127,6 @@
         <dependency>
           <groupId>xyz.block</groupId>
           <artifactId>tbdex-protocol</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xyz.block</groupId>
-            <artifactId>web5</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xyz.block</groupId>
-            <artifactId>web5-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xyz.block</groupId>
-            <artifactId>web5-credentials</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xyz.block</groupId>
-            <artifactId>web5-crypto</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xyz.block</groupId>
-            <artifactId>web5-dids</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>xyz.block</groupId>
-            <artifactId>web5-testing</artifactId>
         </dependency>
     </dependencies>
 
@@ -241,5 +209,11 @@
             <name>jboss</name>
             <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
         </repository>
+      <repository>
+        <id>sonatype-oss-snapshots</id>
+        <name>sonatype-oss-snapshots</name>
+        <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+        <snapshots />
+      </repository>
     </repositories>
 </project>

--- a/site/testsuites/testsuite-kotlin/pom.xml
+++ b/site/testsuites/testsuite-kotlin/pom.xml
@@ -19,7 +19,13 @@
         <version.kotlin>1.9.22</version.kotlin>
         <version.kotlin.compiler.incremental>true</version.kotlin.compiler.incremental>
         <version.junit-jupiter>5.10.1</version.junit-jupiter>
-        <!-- This needs to be uniformly updated as part of the single dependency script from Nick -->
+
+        <!-- TBD Dependencies -->
+        <!--
+        These need to be uniformly updated as part of the
+        single dependency script from Nick
+        -->
+        <version.tbdex>0.8.0-beta</version.tbdex>
         <version.web5>0.10.0</version.web5>
     </properties>
 
@@ -47,6 +53,23 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>
                 <version>${version.kotlin}</version>
+            </dependency>
+
+            <!-- TBD Dependencies -->
+            <dependency>
+              <groupId>xyz.block</groupId>
+              <artifactId>tbdex-httpclient</artifactId>
+              <version>${version.tbdex}</version>
+            </dependency>
+            <dependency>
+              <groupId>xyz.block</groupId>
+              <artifactId>tbdex-httpserver</artifactId>
+              <version>${version.tbdex}</version>
+            </dependency>
+            <dependency>
+              <groupId>xyz.block</groupId>
+              <artifactId>tbdex-protocol</artifactId>
+              <version>${version.tbdex}</version>
             </dependency>
             <dependency>
                 <groupId>xyz.block</groupId>
@@ -98,6 +121,20 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+
+        <!-- TBD Dependencies -->
+        <dependency>
+          <groupId>xyz.block</groupId>
+          <artifactId>tbdex-httpclient</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>xyz.block</groupId>
+          <artifactId>tbdex-httpserver</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>xyz.block</groupId>
+          <artifactId>tbdex-protocol</artifactId>
         </dependency>
         <dependency>
             <groupId>xyz.block</groupId>


### PR DESCRIPTION
Add `tbdex-kt` suite to our testsuite support so it can be tested.

We're going to try this on a temp SNAPSHOT to unblock teams: `xzy.block:tbdex-*:0.9.0-SNAPSHOT`

Will need to be properly handled in a future issue/commit stream once the dep chains of upstream projects are clean.