### PR TITLE
Adding padding on Shnip content

### DIFF
--- a/site/src/components/language/Shnip.jsx
+++ b/site/src/components/language/Shnip.jsx
@@ -30,7 +30,7 @@ const Shnip = ({ snippets, inlineSnippets }) => {
           snippets.map(
             ({ snippetContent, language, title, content }, index) => (
               <div key={`snippet-${language}-${index}`} language={language}>
-                {content && <ReactMarkdown>{content}</ReactMarkdown>}
+                {content && <div style={{ paddingTop: '20px' }}><ReactMarkdown>{content}</ReactMarkdown></div>}
                 <CodeSnippet
                   snippet={snippetContent}
                   language={language.toLowerCase()}
@@ -44,7 +44,7 @@ const Shnip = ({ snippets, inlineSnippets }) => {
           inlineSnippets.map(
             ({ content, code, language, codeLanguage, breakLineAt, title }, index) => (
               <div key={`inline-${language}-${index}`} language={language}>
-                {content && <ReactMarkdown>{content}</ReactMarkdown>}
+                {content && <div style={{ paddingTop: '20px' }}><ReactMarkdown>{content}</ReactMarkdown></div>}
                 {code && <CodeBlock
                   language={(codeLanguage || language).toLowerCase()}
                   title={title}


### PR DESCRIPTION
added a lil breathing room to the shnip text content

**Before**

<img width="846" alt="image" src="https://github.com/TBD54566975/developer.tbd.website/assets/15972783/3f3abe08-293d-4af2-bbb4-3cd75b8f6e39">



**After**

<img width="861" alt="image" src="https://github.com/TBD54566975/developer.tbd.website/assets/15972783/b41fbfdd-4ccb-429b-af83-18bab32a0a10">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206530477402621