### PR TITLE
Changed PFI example service endpoints

### DIFF
--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/onboarding.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/onboarding.js
@@ -6,7 +6,7 @@ const did = await DidDhtMethod.create({
     services: [{
         id: 'pfi',
         type: 'PFI',
-        serviceEndpoint: 'tbdex-pfi.tbddev.org'
+        serviceEndpoint: 'https://example.com/'
     }]
 })
 // :snippet-end:

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/orders.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/orders.js
@@ -6,7 +6,7 @@ var pfiDid = await DidDhtMethod.create({
     services: [{
         id: 'pfi',
         type: 'PFI',
-        serviceEndpoint: 'tbdex-pfi.tbddev.org'
+        serviceEndpoint: 'https://example.com/'
     }]
 })
 

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/pfi-structure.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/pfi-structure.js
@@ -230,7 +230,7 @@ this.pfiDid = await DidDhtMethod.create({
   services: [{
       id: 'pfi',
       type: 'PFI',
-      serviceEndpoint: 'tbdex-pfi.tbddev.org'
+      serviceEndpoint: 'https://example.com/'
   }]
 })
 

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/wallet/allowListPfi.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/wallet/allowListPfi.test.js
@@ -10,7 +10,7 @@ describe('allowlist PFIs', () => {
         services: [{
             id: 'pfi',
             type: 'PFI',
-            serviceEndpoint: 'tbdex-pfi.tbddev.org'
+            serviceEndpoint: 'https://example.com/'
         }]
     })
   });

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiOnboardingTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiOnboardingTest.kt
@@ -23,7 +23,7 @@ class PfiOnboardingTest {
     val serviceToAdd = Service.builder()
         .id(URI("pfi"))
         .type("PFI")
-        .serviceEndpoint("tbdex-pfi.tbddev.org")
+        .serviceEndpoint("https://example.com/")
         .build()
 
     val options = CreateDidDhtOptions(

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiOrdersTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiOrdersTest.kt
@@ -18,7 +18,7 @@ class PfiOrdersTest {
         val serviceToAdd = Service.builder()
             .id(URI("pfi"))
             .type("PFI")
-            .serviceEndpoint("tbdex-pfi.tbddev.org")
+            .serviceEndpoint("https://example.com/")
             .build()
 
         val pfiOptions = CreateDidDhtOptions(

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt
@@ -25,7 +25,7 @@ class PfiStructureTest {
         val serviceToAdd = Service.builder()
             .id(URI("pfi"))
             .type("PFI")
-            .serviceEndpoint("tbdex-pfi.tbddev.org")
+            .serviceEndpoint("https://example.com/")
             .build()
 
         val options = CreateDidDhtOptions(

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/wallet/PfiAllowListTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/wallet/PfiAllowListTest.kt
@@ -20,7 +20,7 @@ class PfiAllowListTest {
         val serviceToAdd = Service.builder()
             .id(URI("pfi"))
             .type("PFI")
-            .serviceEndpoint("tbdex-pfi.tbddev.org")
+            .serviceEndpoint("https://example.com/")
             .build()
 
         val options = CreateDidDhtOptions(


### PR DESCRIPTION
The example endpoints we've been using are `tbdex-pfi.tbddev.org`. However, when testing, these failed because tbDEX is looking for `http`. Went ahead and took TBD out and used an example URL