### PR TITLE
Ability to run JS tests individually

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "pnpm run shnip && pnpm vitest --config vite.config.ts --watch",
     "test:browser": "pnpm -r test:browser",
     "test:versions": "node check-versions.js",
+    "test:js": "pnpm run shnip && pnpm vitest run --config vite.config.ts --no-threads",
     "test:kotlin": "./site/testsuites/testsuite-kotlin/mvnw clean verify -f site/testsuites/testsuite-kotlin",
     "test:swift": "swift test --package-path ./site/testsuites/testsuite-swift",
     "test:rust": "cd ./site/testsuites/testsuite-rust && cargo test",


### PR DESCRIPTION
Added `pnpm test:js` which allows us to only run the JS tests. With this, we can also run an individual test, making it quicker to verify the one test you're working on: ```pnpm test:js getOfferings.test.js```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206571002797197