### PR TITLE
Remove text stating Wallet isn't addressable

### DIFF
--- a/site/docs/tbdex/pfi/creating-quotes.mdx
+++ b/site/docs/tbdex/pfi/creating-quotes.mdx
@@ -71,6 +71,6 @@ With the `Quote` created, you’ll then sign it for authorization purposes and w
   ]} />
 
 :::note
-Wallet Applications are not addressable, and therefore are not pushed updates about Quotes. 
-Therefore the Wallet Application will need to poll the PFI to get the Quote.
+If the Wallet Application supplied a `replyTo` address with their RFQ, you'll send the Quote to that address.
+If not, the Wallet Application will poll your PFI awaiting the Quote message to appear within the exchange.
 :::

--- a/site/docs/tbdex/pfi/processing-orders.mdx
+++ b/site/docs/tbdex/pfi/processing-orders.mdx
@@ -26,9 +26,8 @@ Upon storing the `Order` message, you will want to create an initial <LanguageSw
     { snippetContent: pfiOrdersStatusKt, language: 'Kotlin'}
   ]} />
 
-
-Since the Wallet application isn't addressable, you’ll write the `OrderStatus` to your database and the Wallet will poll for `OrderStatus` data.
-
+If the Wallet Application supplied a `replyTo` address, you'll send the `OrderStatus` message there.
+You can also write the `OrderStatus` to your database and the Wallet will poll for `OrderStatus` data.
 
 ## Process the Order
 


### PR DESCRIPTION
With the new `replyTo` feature, Wallets have the option of having the PFIs reply directly to them. Updated the language in our guides to reflect this.

Will follow with another update showing PFIs how to do this.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206597542673573