### PR TITLE
Added info about replyTo callback in Wallet guides

### DIFF
--- a/site/docs/tbdex/wallet/place-order.mdx
+++ b/site/docs/tbdex/wallet/place-order.mdx
@@ -4,7 +4,6 @@ hide_title: true
 sidebar_position: 9
 ---
 
-
 import createOrderJS from '!!raw-loader!@site/snippets/testsuite-javascript/__tests__/tbdex/wallet/createOrderJS.snippet.js'
 import signOrderJS from '!!raw-loader!@site/snippets/testsuite-javascript/__tests__/tbdex/wallet/signOrderJS.snippet.js'
 import sendOrderJS from '!!raw-loader!@site/snippets/testsuite-javascript/__tests__/tbdex/wallet/sendOrderJS.snippet.js'
@@ -60,10 +59,12 @@ This is done using the `TbdexHttpClient.sendMessage` method:
 
 
 ## Listen for Order Status Updates
-As the PFI is processing the Order, they'll write `OrderStatus` messages to the exchange to keep you posted on the Order's status.
+As the PFI is processing the Order, they'll provide `OrderStatus` messages. 
 Your application would likely want to show these status updates to your customer to keep them informed of progress.
 
-Your application can poll the exchange to continuously check for `OrderStatus` messages until a `Close` message has been written to the exchange:
+If you provided a [callback URI](/docs/tbdex/wallet/send-rfq#send-rfq-to-pfi) when sending the RFQ, the PFI will send the `OrderStatus` messages there.
+
+Otherwise, the PFI will write the `OrderStatus` messages to the exchange to keep you posted on the Order's status, and your application can poll the exchange to continuously check for `OrderStatus` messages until a `Close` message has been written to the exchange:
 
 <Shnip
   snippets={[

--- a/site/docs/tbdex/wallet/receive-quote.mdx
+++ b/site/docs/tbdex/wallet/receive-quote.mdx
@@ -19,7 +19,7 @@ This message will be written to the exchange.
 
 ## Polling for Quote
 
-To get the Quote message, your application will poll the exchange until the Quote message is written:
+If you did not provide a [callback URI](/docs/tbdex/wallet/send-rfq#send-rfq-to-pfi) when sending a RFQ, your application will need to poll the exchange until the Quote message is written:
 
 <Shnip
   snippets={[
@@ -75,5 +75,3 @@ To terminate the exchange, create a `Close` message, sign it with the customer's
 />
 
 At this point, the exchange has been closed, and your customer is free to start a new exchange with this PFI or any other.
-
-

--- a/site/docs/tbdex/wallet/send-rfq.mdx
+++ b/site/docs/tbdex/wallet/send-rfq.mdx
@@ -83,7 +83,9 @@ Use `TbdexHttpClient` to send the RFQ to the PFI, with an optional `replyTo` pro
   ]}
 />
 
-:::tip
+:::tip Callback
+Callbacks are implemented via the `replyTo` property on the RFQ message, and is a fully qualified URI which could either be a DID or URL.
+
 If `replyTo` is provided, the PFI will send all new messages of the exchange to the supplied URI. 
 This URI is scoped to each exchange, allowing you to specify a different URI per exchange if desired. 
 

--- a/site/docs/tbdex/wallet/send-rfq.mdx
+++ b/site/docs/tbdex/wallet/send-rfq.mdx
@@ -84,12 +84,12 @@ Use `TbdexHttpClient` to send the RFQ to the PFI, with an optional `replyTo` pro
 />
 
 :::tip Callback
-Callbacks are implemented via the `replyTo` property on the RFQ message, and is a fully qualified URI which could either be a DID or URL.
+Callbacks are fully qualified URIs (DID or URL) that can be provided to the PFI via the `replyTo` property on the RFQ message.
 
 If `replyTo` is provided, the PFI will send all new messages of the exchange to the supplied URI. 
 This URI is scoped to each exchange, allowing you to specify a different URI per exchange if desired. 
 
-If `replyTo` is _not_ present, you will have to poll the PFI to receive new messages within the exchange.
+If `replyTo` is _not_ present, you will need to poll the PFI to receive new messages within the exchange.
 :::
 
 If no error is thrown, the RFQ has been successfully sent to the PFI and an **exchange** has been created.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 📝 Documentation Update

## Description

This PR updates the Wallet guides to include info about the `replyTo` callback

## Direct preview links

- [Sending RFQs](https://deploy-preview-1260--tbd-website-developer.netlify.app/docs/tbdex/wallet/send-rfq#send-rfq-to-pfi)
- [Receiving Quotes](https://deploy-preview-1260--tbd-website-developer.netlify.app/docs/tbdex/wallet/receive-quote#polling-for-quote)
- [Placing Orders](https://deploy-preview-1260--tbd-website-developer.netlify.app/docs/tbdex/wallet/place-order#listen-for-order-status-updates)

## Added code snippets?
- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [X] 🙋 no, because I need help


## Added to documentation?

- [ ] 📜 readme
- [ ] 📜 contributing.md
- [ ] 📓 general documentation
- [X] 🙅 no documentation needed


## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ3ZiaXlqdXBjanljMzI0azhvdXBucjVwY2YwYWdkMnRiY203MXFmdCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xUA7aWmr0uddsafLEI/giphy.gif)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206597542673569
  - https://app.asana.com/0/0/1206597542673572