### PR TITLE
Pointing to web5js API Ref guide

### DIFF
--- a/site/docs/api.mdx
+++ b/site/docs/api.mdx
@@ -16,7 +16,7 @@ import ApiCard from '@site/src/components/ApiCard';
       name="Web5 SDK"
       description="A library for generating and resolving Decentralized Identifiers, as well as issuing, presenting and verifying Verifiable Credentials. The JS SDK also includes convenience methods for working with Decentralized Web Nodes."
       links={[
-        {"js": "/api/web5-js"},
+        {"js": "https://tbd54566975.github.io/web5-js/"},
         {"kt": "https://tbd54566975.github.io/web5-kt/docs/htmlMultiModule/index.html"}
       ]}
     />


### PR DESCRIPTION
Updated API Reference Guides page to point web5.js to the external docs

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206597543849491