### PR TITLE
ALR Skunkworks testing: Java as a docs language

### DIFF
--- a/shnippet.config.json
+++ b/shnippet.config.json
@@ -1,7 +1,7 @@
 {
   "rootDirectory": "./site/testsuites",
   "outputDirectory": "./site/snippets",
-  "fileExtensions": [".js", ".ts", ".kt", ".gradle", ".xml", ".bash"],
+  "fileExtensions": [".java", ".js", ".ts", ".kt", ".gradle", ".xml", ".bash"],
   "exclude": ["pfiOverviewReadOfferingsJs", "pfiOverviewWriteJs", "pfiOverviewWriteOfferingsJs"],
   "snippetTags": {
     "start": ":snippet-start:",

--- a/site/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
+++ b/site/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
@@ -9,7 +9,7 @@ import createADidDependencyGradle from '!!raw-loader!@site/snippets/testsuite-ja
 import createADidDependencyMaven from '!!raw-loader!@site/snippets/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/createADidDependencyMaven.snippet.xml';
 import createADidDependency from '!!raw-loader!@site/snippets/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/createADidDependency.snippet.bash';
 
-<LanguageSwitcher languages="JavaScript, Kotlin" />
+<LanguageSwitcher languages="JavaScript, Kotlin, Java" />
 
 # Create a DID
 
@@ -34,7 +34,20 @@ You can create a DID using any of the [Web5-supported DID methods](/docs/web5/le
       nestedSnippets: {
         Gradle: {
           snippet: createADidDependencyGradle,
-          language: 'js',
+          language: 'kt',
+        },
+        Maven: {
+          snippet: createADidDependencyMaven,
+          language: 'xml',
+        },
+      },
+    },
+    {
+      language: 'Java',
+      nestedSnippets: {
+        Gradle: {
+          snippet: createADidDependencyGradle,
+          language: 'kt',
         },
         Maven: {
           snippet: createADidDependencyMaven,
@@ -63,6 +76,7 @@ The following DID methods are supported:
   snippets={[
     { snippetName: 'createDidDht', language: 'JavaScript' },
     { snippetName: 'createDidDhtKt', language: 'Kotlin' },
+    { snippetName: 'createDidDhtJava', language: 'Java' },
   ]}
 />
 
@@ -73,6 +87,7 @@ The following DID methods are supported:
   snippets={[
     { snippetName: 'createDidJwk', language: 'JavaScript' },
     { snippetName: 'createDidJwkKt', language: 'Kotlin' },
+    { snippetName: 'createDidJwkJava', language: 'Java' },
     ]}
 />
 

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -256,7 +256,8 @@ let config = {
             },
           ],
         },
-        additionalLanguages: ['kotlin', 'swift', 'dart', 'rust'],
+        // Must add Scala here to work around a Redoc bug: https://github.com/facebook/docusaurus/issues/7209
+        additionalLanguages: ['kotlin', 'swift', 'dart', 'rust', 'java', 'scala'],
       },
     }),
 };

--- a/site/src/components/CodeSnippet.jsx
+++ b/site/src/components/CodeSnippet.jsx
@@ -5,6 +5,7 @@ import codeSnippets from '../../src/util/code-snippets-map.json'; // Import for 
 // Define the language map for the new system
 const languageExtensionMap = {
   javascript: 'js',
+  java: 'java',
   kotlin: 'kt',
   swift: 'swift',
   dart: 'dart',

--- a/site/testsuites/kotlin-testsuite.iml
+++ b/site/testsuites/kotlin-testsuite.iml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AutoImportedSourceRoots">
+    <option name="directories">
+      <list>
+        <option value="$MODULE_DIR$/testsuite-kotlin/src/main/java" />
+        <option value="$MODULE_DIR$/testsuite-kotlin/src/main/kotlin" />
+        <option value="$MODULE_DIR$/testsuite-kotlin/src/test/java" />
+        <option value="$MODULE_DIR$/testsuite-kotlin/src/test/kotlin" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/site/testsuites/testsuite-kotlin/kotlin-testsuite.iml
+++ b/site/testsuites/testsuite-kotlin/kotlin-testsuite.iml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AutoImportedSourceRoots">
+    <option name="directories">
+      <list>
+        <option value="$MODULE_DIR$/src/main/java" />
+        <option value="$MODULE_DIR$/src/main/kotlin" />
+        <option value="$MODULE_DIR$/src/test/java" />
+        <option value="$MODULE_DIR$/src/test/kotlin" />
+      </list>
+    </option>
+  </component>
+</module>

--- a/site/testsuites/testsuite-kotlin/pom.xml
+++ b/site/testsuites/testsuite-kotlin/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>17</java.version>
         <kotlin.jvm.target>17</kotlin.jvm.target>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <version.assertj>3.25.2</version.assertj>
@@ -121,8 +122,8 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
         <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
             <plugins>
                 <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
@@ -179,6 +180,66 @@
                 <configuration>
                     <jvmTarget>${kotlin.jvm.target}</jvmTarget>
                 </configuration>
+                <executions>
+                  <execution>
+                    <id>compile</id>
+                    <phase>process-sources</phase>
+                    <goals>
+                      <goal>compile</goal>
+                    </goals>
+                    <configuration>
+                      <sourceDirs>
+                        <sourceDir>${project.basedir}/src/main/java</sourceDir>
+                        <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+                      </sourceDirs>
+                    </configuration>
+                  </execution>
+                  <execution>
+                    <id>test-compile</id>
+                    <phase>process-test-sources</phase>
+                    <goals>
+                      <goal>test-compile</goal>
+                    </goals>
+                    <configuration>
+                      <sourceDirs>
+                        <sourceDir>${project.basedir}/src/test/java</sourceDir>
+                        <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+                      </sourceDirs>
+                    </configuration>
+                  </execution>
+                </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <source>${java.version}</source>
+                <target>${java.version}</target>
+              </configuration>
+              <executions>
+                <execution>
+                  <id>default-compile</id>
+                  <phase>none</phase>
+                </execution>
+                <execution>
+                  <id>default-testCompile</id>
+                  <phase>none</phase>
+                </execution>
+                <execution>
+                  <id>java-compile</id>
+                  <phase>compile</phase>
+                  <goals>
+                    <goal>compile</goal>
+                  </goals>
+                </execution>
+                <execution>
+                  <id>java-test-compile</id>
+                  <phase>test-compile</phase>
+                  <goals>
+                    <goal>testCompile</goal>
+                  </goals>
+                </execution>
+              </executions>
             </plugin>
         </plugins>
     </build>

--- a/site/testsuites/testsuite-kotlin/src/test/java/website/tbd/developer/site/java/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.java
+++ b/site/testsuites/testsuite-kotlin/src/test/java/website/tbd/developer/site/java/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.java
@@ -1,0 +1,63 @@
+package website.tbd.developer.site.java.docs.web5.build.decentralizedidentifiers;
+
+import foundation.identity.did.DIDDocument;
+import org.junit.jupiter.api.Test;
+import web5.sdk.crypto.InMemoryKeyManager;
+import web5.sdk.dids.DidResolutionResult;
+import web5.sdk.dids.methods.dht.CreateDidDhtOptions;
+import web5.sdk.dids.methods.dht.DidDht;
+import web5.sdk.dids.methods.jwk.DidJwk;
+import web5.sdk.dids.methods.key.DidKey;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HowToCreateDidTest
+{
+
+  @Test
+  void createDidDht(){
+
+    // :snippet-start: createDidDhtJava
+    // Creates a DID using the DHT method and publishes the DID Document to the DHT
+    final DidDht didDht = DidDht.Default.create(
+      new InMemoryKeyManager(),
+      new CreateDidDhtOptions(null,null,true,null,null));
+
+    // DID String
+    final String did = didDht.getUri();
+
+    // DID and its associated data which can be exported and used in different contexts/apps
+    final DidResolutionResult portableDid = DidDht.Default.resolve(did,null);
+
+    // DID Document
+    final DIDDocument didDocument = portableDid.getDidDocument();
+    // :snippet-end:
+
+    assertNotNull(did,"DID should not be null");
+    assertTrue(did.startsWith("did:dht"),"Did should start with 'did:dht'");
+    assertEquals(did, didDocument.getId().toString(),"ID of DID Document should match DID");
+  }
+
+  @Test
+  void createDidJwt() {
+    // :snippet-start: createDidJwkJava
+    // Creates a DID using the did:jwk method
+    final DidJwk didJwk = DidJwk.Companion.create(new InMemoryKeyManager(), null);
+
+    // DID and its associated data which can be exported and used in different contexts/apps
+    final DidResolutionResult portableDid = didJwk.resolve();
+
+    // DID String
+    final String did = didJwk.getUri();
+
+    // DID Document
+    final DIDDocument didDocument = portableDid.getDidDocument();
+    // :snippet-end:
+
+    assertNotNull(did, "DID should not be null");
+    assertTrue(did.startsWith("did:jwk"), "DID should start with 'did:jwk'");
+    assertNotNull(didDocument, "DID Document should not be null");
+    assertEquals(did, didDocument.getId().toString(),"ID od DID Document should match DID");
+  }
+
+}


### PR DESCRIPTION
This is a test; as of now, it's not an incoming PR.

A little trial I'm vetting to see the lift involved in writing Java docs examples calling upon the JVM bytecode available to it from `tbdex-kt` and `web5-kt`.

* Configure Kotlin and Java sources to coexist in the testsuite
* Make a real Java port of an existing Kotlin test
* Hook Java snippets into docs
* Add Java support to Shnippet
* Configure Docusaurus CodeBlock component for Java syntax highlighting
* Add Java support to CodeSnippet component

Looks like:
![Screenshot at 2024-02-20 04-22-26](https://github.com/TBD54566975/developer.tbd.website/assets/199891/9eeb47eb-4c5c-4b8e-821a-9c66b42f5342)

TODO: 
* Refactor `testsuite-kotlin` to `testsuite-jvm` or even better, just `jvm` alongside the other suite becoming `js` instead of `testsuite-js`
* Get `import` statements in the trial Java test to come from real code, and surface in docs
* Why is Netlify failing? Sync w/ the King of This Stuff, @dayhaysoos, for assistance. Error message provided is trash and he's good at just, like, knowing what it's complaining about.
* If we do this, shall we add JavaDoc API References to the Kotlin SDK? [Looks possible](https://kotlinlang.org/docs/dokka-javadoc.html#generate-javadoc-documentation).
* Even though these tests work, validate with upstream Kotlin team that my test is using the preferred Java call paths ported from Kotlin:

```
// Creates a DID using the did:jwk method
final DidJwk didJwk = DidJwk.Companion.create(new InMemoryKeyManager(), null);

// DID and its associated data which can be exported and used in different contexts/apps
final DidResolutionResult portableDid = didJwk.resolve();

// DID String
final String did = didJwk.getUri();

// DID Document
final DIDDocument didDocument = portableDid.getDidDocument();
```