### PR TITLE
removing JS-specific link

### DIFF
--- a/site/docs/tbdex/message-types.mdx
+++ b/site/docs/tbdex/message-types.mdx
@@ -23,7 +23,7 @@ PFIs and Wallets are able to communicate with each other by using the following 
 ## Offerings
 
 [Offerings](/docs/tbdex/pfi/creating-offerings) describe a currency pair that can be exchanged and include requirements, conditions, and constraints needed to fulfill the described transaction. 
-They are created and stored by PFIs, and they are consumed via the [OfferingsApi](https://tbd54566975.github.io/tbdex-js/interfaces/_tbdex_http_server.OfferingsApi.html) by Wallets. 
+They are created and stored by PFIs, and they are consumed by Wallets.
 
 ## Exchanges
 


### PR DESCRIPTION
This pull request includes a small change in the `site/docs/tbdex/message-types.mdx` file. The change simplifies the explanation of how Offerings are consumed, removing the specific mention of the `OfferingsApi`.