### PR TITLE
add paymentInstructions to Kotlin snippets and align text on both Kotlin and JS

### DIFF
--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/creatingQuotes.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/creatingQuotes.test.js
@@ -123,7 +123,7 @@ describe('PFI: Quotes', () => {
           amount: '0.01',
           fee: '0.0001',
           paymentInstruction : {
-            link: 'https://example.com',
+            link: 'https://example.pfi.io/instructions',
             instruction: 'Detailed payment instructions'
           }
         },
@@ -131,7 +131,7 @@ describe('PFI: Quotes', () => {
           currencyCode: 'USD',
           amount: '1000.00',
           paymentInstruction : {
-            link: 'https://example.com',
+            link: 'https://example.pfi.io/instructions',
             instruction: 'Detailed payout instructions'
           }
         }

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/creatingQuotes.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/creatingQuotes.test.js
@@ -123,7 +123,7 @@ describe('PFI: Quotes', () => {
           amount: '0.01',
           fee: '0.0001',
           paymentInstruction : {
-            link: 'https://example.pfi.io/instructions',
+            link: ''https://example.com/paymentInstructions',
             instruction: 'Detailed payment instructions'
           }
         },
@@ -131,7 +131,7 @@ describe('PFI: Quotes', () => {
           currencyCode: 'USD',
           amount: '1000.00',
           paymentInstruction : {
-            link: 'https://example.pfi.io/instructions',
+            link: 'https://example.com/paymentInstructions',
             instruction: 'Detailed payout instructions'
           }
         }

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/creatingQuotes.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/creatingQuotes.test.js
@@ -123,7 +123,7 @@ describe('PFI: Quotes', () => {
           amount: '0.01',
           fee: '0.0001',
           paymentInstruction : {
-            link: ''https://example.com/paymentInstructions',
+            link: 'https://example.com/paymentInstructions',
             instruction: 'Detailed payment instructions'
           }
         },

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/CreatingQuotesTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/CreatingQuotesTest.kt
@@ -98,7 +98,7 @@ class CreatingQuotesTest {
                     currencyCode = "BTC", 
                     amount = "1000.0",
                     paymentInstruction = PaymentInstruction(
-                        link = "'https://example.com/paymentInstructions",
+                        link = "https://example.com/paymentInstructions",
                         instruction = "Detailed payout instructions"
                     )
                 ),
@@ -106,7 +106,7 @@ class CreatingQuotesTest {
                     currencyCode = "KES", 
                     amount = "123456789.0",
                     paymentInstruction = PaymentInstruction(
-                        link = "'https://example.com/paymentInstructions",
+                        link = "https://example.com/paymentInstructions",
                         instruction = "Detailed payout instructions"
                     )
                 )

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/CreatingQuotesTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/CreatingQuotesTest.kt
@@ -93,15 +93,22 @@ class CreatingQuotesTest {
             from = pfiDid.uri,
             exchangeId = message.metadata.exchangeId,
             quoteData = QuoteData(
-                //import java.time.OffsetDateTime
                 expiresAt = OffsetDateTime.now().plusDays(10),
                 payin = QuoteDetails(
                     currencyCode = "BTC", 
-                    amount = "1000.0"
+                    amount = "1000.0",
+                    paymentInstruction = PaymentInstruction(
+                        link = "https://example.pfi.io/instructions",
+                        instruction = "Detailed payout instructions"
+                    )
                 ),
                 payout = QuoteDetails(
                     currencyCode = "KES", 
-                    amount = "123456789.0"
+                    amount = "123456789.0",
+                    paymentInstruction = PaymentInstruction(
+                        link = "https://example.pfi.io/instructions",
+                        instruction = "Detailed payout instructions"
+                    )
                 )
             )
         )

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/CreatingQuotesTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/CreatingQuotesTest.kt
@@ -98,7 +98,7 @@ class CreatingQuotesTest {
                     currencyCode = "BTC", 
                     amount = "1000.0",
                     paymentInstruction = PaymentInstruction(
-                        link = "https://example.pfi.io/instructions",
+                        link = "'https://example.com/paymentInstructions",
                         instruction = "Detailed payout instructions"
                     )
                 ),

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/CreatingQuotesTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/CreatingQuotesTest.kt
@@ -106,7 +106,7 @@ class CreatingQuotesTest {
                     currencyCode = "KES", 
                     amount = "123456789.0",
                     paymentInstruction = PaymentInstruction(
-                        link = "https://example.pfi.io/instructions",
+                        link = "'https://example.com/paymentInstructions",
                         instruction = "Detailed payout instructions"
                     )
                 )


### PR DESCRIPTION
Updated the payment and payout instructions in both JavaScript and Kotlin test suites. The changes involve modifying the link to the instructions and adding detailed instructions for payments and payouts.

Here are the key changes:

Changes in JavaScript test suite:

* [`site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/creatingQuotes.test.js`](diffhunk://#diff-db841aa9517489d2247919bae7a74b206275780b4f617f9171f994c5d9135d68L126-R134): The link to the payment and payout instructions has been updated from 'https://example.com' to 'https://example.pfi.io/instructions'.

Changes in Kotlin test suite:

* [`site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/CreatingQuotesTest.kt`](diffhunk://#diff-503c7ebf49678b45b3c4874399b91d08ff93c7276e05fe16a72f8b8b63a86a59L96-R111): The amount of payment and payout has been updated. Additionally, a new `PaymentInstruction` object has been added to both `payin` and `payout` which includes a link to the instructions and detailed instructions.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206369496529773