### PR TITLE
Added Deep Dive button to Web5 docs

### DIFF
--- a/site/docs/web5/index.mdx
+++ b/site/docs/web5/index.mdx
@@ -32,6 +32,15 @@ The Web5 SDK helps you create a decentralized app in minutes.
     {
       type: 'button',
       data: {
+        label: 'Deep Dive',
+        url: '/blog/what-is-web5/',
+        isExternalLink: false,
+        imageURL: '/img/external-link-blue-icon.svg',
+      },
+    },
+    {
+      type: 'button',
+      data: {
         label: 'Quickstart',
         url: 'quickstart',
         isExternalLink: false,


### PR DESCRIPTION
Added "Deep Dive" button on Web5 docs index page that links to "What is Web5" blog post

<img width="1233" alt="image" src="https://github.com/TBD54566975/developer.tbd.website/assets/15972783/b7bcbe7a-1841-421d-95ef-6c283336bbb0">
