### PR TITLE
Add Kotlin tests for verifying PFI routes

### DIFF
--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt
@@ -71,7 +71,6 @@ class PfiStructureTest {
          * Assert that the 3 are rfq, order, and close
          */
         // check that tbDex.callbacks 
-        val expectedCallbacks = setOf(SubmitKind.rfq, SubmitKind.order, SubmitKind.close)
         val actualCallbacks = tbDexServer.callbacks
         assertTrue(actualCallbacks.contains(SubmitKind.rfq), "Callbacks should contain rfq")
         assertTrue(actualCallbacks.contains(SubmitKind.order), "Callbacks should contain order")

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt
@@ -70,6 +70,13 @@ class PfiStructureTest {
          * Assert that there are 3 callbacks registered
          * Assert that the 3 are rfq, order, and close
          */
+        // check that tbDex.callbacks 
+        val expectedCallbacks = setOf(SubmitKind.rfq, SubmitKind.order, SubmitKind.close)
+        val actualCallbacks = tbDexServer.callbacks
+        assertTrue(actualCallbacks.contains(SubmitKind.rfq), "Callbacks should contain rfq")
+        assertTrue(actualCallbacks.contains(SubmitKind.order), "Callbacks should contain order")
+        assertTrue(actualCallbacks.contains(SubmitKind.close), "Callbacks should contain close")
+        assertEquals(tbDexServer.callbacks.size, 3, "There should be 3 routes")
     }
 
     @Test


### PR DESCRIPTION
This pull request includes changes to the `PfiStructureTest` class in the `site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt` file. The changes add assertions to verify the number and types of callbacks registered in the `tbDexServer`.

The key changes are:

* Added a set of expected callbacks, which includes `SubmitKind.rfq`, `SubmitKind.order`, and `SubmitKind.close`.
* Retrieved the actual callbacks from `tbDexServer` and stored them in `actualCallbacks`.
* Added assertions to check if `actualCallbacks` contains `SubmitKind.rfq`, `SubmitKind.order`, and `SubmitKind.close`.
* Added an assertion to verify that the size of `tbDexServer.callbacks` is 3.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206815562903712