### PR TITLE
[Bug] Select a different language tab if default lang is missing

### DIFF
--- a/site/src/components/language/LanguageTabBar.jsx
+++ b/site/src/components/language/LanguageTabBar.jsx
@@ -8,7 +8,7 @@ const LanguageTabBar = () => {
     var currentLanguage = useLanguage().language;
     const { languages } = useSupportedLanguages();
     var activeTab = currentLanguage;
-  
+
     const setActiveTab = (tab) => {
         changeLanguage(tab);
         updateUrl(tab);
@@ -18,14 +18,18 @@ const LanguageTabBar = () => {
         }
     }
 
+    if (!languages.includes(currentLanguage)) {
+      setActiveTab(languages[0]);
+    }
+
   return (
       <div className='languageTabs'>
         {languages.map(tab => (
           <div
-            key={tab} 
+            key={tab}
             onClick={() => setActiveTab(tab)}
-            style={{ 
-              padding: '20px', 
+            style={{
+              padding: '20px',
               borderBottom: activeTab === tab ? '2px solid yellow' : 'none',
               borderRadius: '10px 10px 0 0',
               background: activeTab === tab ? '#282828' : 'none'


### PR DESCRIPTION
This pull request includes a minor change to the `LanguageTabBar` component in the `site/src/components/language/LanguageTabBar.jsx` file. The change ensures that if the `currentLanguage` is not included in the `languages` array, the `activeTab` is set to the first language in the `languages` array. This prevents any potential issues that could arise if the `currentLanguage` is not a valid option.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206879252502944