### PR TITLE
Add OSP Reusable Workflow for Scans

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,7 +1,7 @@
-name: Security Scanning
+name: Security and License Scans
 
 on:
-  pull_request_target:
+  pull_request: #todo: _target:
     branches:
       - main
 
@@ -17,22 +17,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  fossa:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-
-      - name: Run FOSSA Scan
-        uses: fossas/fossa-action@main
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-
-      - name: Run FOSSA Test
-        uses: fossas/fossa-action@main
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          run-tests: true
+  security-license-scan:
+    uses: TBD54566975/open-source-programs/.github/workflows/security.yml@leordev/reusable-workflows
+    secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,7 +1,7 @@
 name: Security and License Scans
 
 on:
-  pull_request: #todo: _target:
+  pull_request_target:
     branches:
       - main
 
@@ -18,5 +18,5 @@ on:
 
 jobs:
   security-license-scan:
-    uses: TBD54566975/open-source-programs/.github/workflows/security.yml@leordev/reusable-workflows
+    uses: TBD54566975/open-source-programs/.github/workflows/security.yml@main
     secrets: inherit


### PR DESCRIPTION
We are centralizing our workflows in the OSP repo. With that we are extracting the FOSSA checks, which is already improved by:
1. Checking if your PR is introducing the found vuln/license issue. (yellow arrow in the screenshot)
1. Splitting the License and Security checks (blue arrow)

![image](https://github.com/TBD54566975/developer.tbd.website/assets/6147142/579e2af4-9dbb-49ae-b9bc-cee46876ee44)
