### PR TITLE
Remove danubetech from dependencies

### DIFF
--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did-dependency.gradle
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did-dependency.gradle
@@ -2,7 +2,6 @@
 // :snippet-start: createADidDependencyGradle
 repositories {
     mavenCentral()
-    maven("https://repo.danubetech.com/repository/maven-public/")
 }
 dependencies {
     implementation("xyz.block:web5-dids:0.10.0")

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did-dependency.xml
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did-dependency.xml
@@ -5,10 +5,6 @@
         <id>mavenCentral</id>
         <url>https://repo1.maven.org/maven2/</url>
     </repository>
-    <repository>
-        <id>danubetech-maven-public</id>
-        <url>https://repo.danubetech.com/repository/maven-public/</url>
-    </repository>
 </repositories>
 
 <dependencies>

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/CredentialIssuance.gradle
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/CredentialIssuance.gradle
@@ -3,7 +3,6 @@
 repositories {
   mavenCentral()
   maven("https://jitpack.io")
-  maven("https://repo.danubetech.com/repository/maven-public/")
 }
 // Configure dependencies
 dependencies {

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/CredentialIssuance.xml
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/CredentialIssuance.xml
@@ -4,10 +4,6 @@
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>danubetech-maven-public</id>
-            <url>https://repo.danubetech.com/repository/maven-public/</url>
-        </repository>
 </repositories>
 
 <dependencies>

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/required-sdks.gradle
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/required-sdks.gradle
@@ -1,7 +1,6 @@
 // :snippet-start: pfiSdkInstallGradle
 repositories {
         mavenCentral()
-        maven("https://repo.danubetech.com/repository/maven-public/")
 }
 dependencies {
         implementation("xyz.block:tbdex:0.10.0-beta")

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/required-sdks.xml
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/required-sdks.xml
@@ -4,10 +4,6 @@
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>danubetech-maven-public</id>
-            <url>https://repo.danubetech.com/repository/maven-public/</url>
-        </repository>
 </repositories>
 
 <dependencies>

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/wallet/required-sdks.gradle
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/wallet/required-sdks.gradle
@@ -1,7 +1,6 @@
 // :snippet-start: walletSdkInstallGradle
 repositories {
         mavenCentral()
-        maven("https://repo.danubetech.com/repository/maven-public/")
 }
 dependencies {
         implementation("xyz.block:web5-credentials:0.0.9-delta")

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/wallet/required-sdks.xml
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/wallet/required-sdks.xml
@@ -4,10 +4,6 @@
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>danubetech-maven-public</id>
-            <url>https://repo.danubetech.com/repository/maven-public/</url>
-        </repository>
 </repositories>
 
 <dependencies>

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/key-management-dependency.gradle
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/key-management-dependency.gradle
@@ -2,7 +2,6 @@
 // Configure repositories
 repositories {
   mavenCentral()
-  maven("https://repo.danubetech.com/repository/maven-public/")
 }
 // Configure dependencies
 dependencies {

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/key-management-dependency.xml
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/key-management-dependency.xml
@@ -4,10 +4,6 @@
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>danubetech-maven-public</id>
-            <url>https://repo.danubetech.com/repository/maven-public/</url>
-        </repository>
 </repositories>
 
 <dependencies>

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/verifiablecredentials/fan-club-sdks.gradle
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/verifiablecredentials/fan-club-sdks.gradle
@@ -2,7 +2,6 @@
 // Configure repositories
 repositories {
         mavenCentral()
-        maven("https://repo.danubetech.com/repository/maven-public/")
 }
 // Configure dependencies
 dependencies {

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/verifiablecredentials/fan-club-sdks.xml
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/verifiablecredentials/fan-club-sdks.xml
@@ -4,10 +4,6 @@
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>danubetech-maven-public</id>
-            <url>https://repo.danubetech.com/repository/maven-public/</url>
-        </repository>
 </repositories>
 
 <dependencies>

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/verifiablecredentials/required-sdks.gradle
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/verifiablecredentials/required-sdks.gradle
@@ -1,7 +1,6 @@
 // :snippet-start: vcSdkInstallGradle
 repositories {
         mavenCentral()
-        maven("https://repo.danubetech.com/repository/maven-public/")
 }
 dependencies {
         implementation("xyz.block:web5-credentials:0.0.11")

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/verifiablecredentials/required-sdks.xml
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/verifiablecredentials/required-sdks.xml
@@ -4,10 +4,6 @@
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>danubetech-maven-public</id>
-            <url>https://repo.danubetech.com/repository/maven-public/</url>
-        </repository>
 </repositories>
 
 <dependencies>


### PR DESCRIPTION
This PR removes any dependency references to danubetech to simplify and clean up any Gradle/Maven dependencies.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206921594576817