### PR TITLE
Removing optional `externalId` from Swift snippets

### DIFF
--- a/site/testsuites/testsuite-swift/Package.resolved
+++ b/site/testsuites/testsuite-swift/Package.resolved
@@ -123,7 +123,7 @@
       "location" : "https://github.com/TBD54566975/tbdex-swift.git",
       "state" : {
         "branch" : "main",
-        "revision" : "cdd63551a066a76837097207b3d9c1e9d20ce8a6"
+        "revision" : "b18f187f646fffdbd70a08697c2108f2250e58dc"
       }
     },
     {
@@ -132,7 +132,7 @@
       "location" : "https://github.com/TBD54566975/web5-swift.git",
       "state" : {
         "branch" : "main",
-        "revision" : "3fac8ccd56c57c05112f459787cecbef25c5d0bf"
+        "revision" : "8f8d65b80dc7c8fe9ef5cecba05ba68cc8dff533"
       }
     }
   ],

--- a/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/MockData.swift
+++ b/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/MockData.swift
@@ -54,7 +54,6 @@ public struct MockData {
                 ),
                 claims: []
             ),
-            externalID: nil,
             protocol: "1.0"
         )
 
@@ -87,7 +86,6 @@ public struct MockData {
                     fee: "0.50"
                 )
             ),
-            externalID: nil,
             protocol: "1.0"
         )
     }
@@ -102,7 +100,6 @@ public struct MockData {
                 to: to,
                 exchangeID: exchangeId,
                 data: .init(),
-                externalID: nil,
                 protocol: "1.0"
             )
     }
@@ -120,7 +117,6 @@ public struct MockData {
             data: .init(
                 orderStatus: status
             ),
-            externalID: nil,
             protocol: "1.0"
         )
     }
@@ -138,7 +134,6 @@ public struct MockData {
             data: .init(
                 reason: reason
             ),
-            externalID: nil,
             protocol: "1.0"
         )
     }
@@ -171,7 +166,6 @@ public struct MockData {
                     fee: "0.50"
                 )
             ),
-            externalID: nil,
             protocol: "1.0"
         )
     }

--- a/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/tbdex/wallet/PlaceOrderTests.swift
+++ b/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/tbdex/wallet/PlaceOrderTests.swift
@@ -31,7 +31,6 @@ final class PlaceOrderTests: XCTestCase {
             to: pfiDid, // PFI's DID
             exchangeID: quote!.metadata.exchangeID, // Exchange ID from the Quote
             data: .init(),
-            externalID: nil,
             protocol: "1.0"
         )
         // :snippet-end:

--- a/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/tbdex/wallet/ReceiveQuoteTests.swift
+++ b/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/tbdex/wallet/ReceiveQuoteTests.swift
@@ -74,7 +74,6 @@ final class ReceiveQuotes: XCTestCase {
             to: quote!.metadata.from,
             exchangeID: quote!.metadata.exchangeID,
             data: CloseData(reason: "Canceled by customer"),
-            externalID: nil,
             protocol: "1.0"
         )
         try! closeMessage.sign(did: customerDid!)

--- a/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/tbdex/wallet/SendingRfqTests.swift
+++ b/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/tbdex/wallet/SendingRfqTests.swift
@@ -76,7 +76,6 @@ final class SendingRfqTests: XCTestCase {
                     ),
                     claims: selectedCredentials // Array of signed VCs required by the PFI
                 ),
-                externalID: nil,
                 protocol: "1.0"
                 //highlight-end
             )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 📝 Documentation Update


## Description

Removed nil `externalId` property from Swift messages

## Related Tickets & Documents

Resolves #1350 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206921594576825