### PR TITLE
Use Docker Compose v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install
 
       - name: Start dwn-server container
-        run: docker-compose up -d dwn-server
+        run: docker compose up -d dwn-server
   
       - name: Wait for dwn-server to be ready
         run: until curl -sf http://localhost:3000/health; do echo -n .; sleep .1; done


### PR DESCRIPTION
v1 is Deprecated and now being removed from runner images effective today.

https://github.com/actions/runner-images/issues/9557