### PR TITLE
Dynamically rendering dependency versions in docs

### DIFF
--- a/site/docs/tbdex/issuer/kcc/kcc-wallet.mdx
+++ b/site/docs/tbdex/issuer/kcc/kcc-wallet.mdx
@@ -28,36 +28,12 @@ For a detailed guide on Known Customer Credentials for **Issuers**, please refer
 
 Your Wallet App will require libraries for handling HTTP requests and processing [JSON Web Tokens(JWTs)](https://jwt.io/). You can include these libraries in your project by installing the following dependencies:
 
-<Shnip
-  snippets={[
-    {
-      snippetName: 'knownCustomerCredentialJsPackage',
-      language: 'JavaScript',
-      codeLanguage: 'bash',
-    },
-    {
-      language: 'Kotlin',
-      nestedSnippets: {
-        Gradle: {
-          snippetName: 'knownCustomerCredentialGradlePackage',
-          language: 'gradle',
-        },
-        Maven: {
-          snippetName: 'knownCustomerCredentialMavenPackage',
-          language: 'xml',
-        },
-      },
-    },
-  ]}
-  inlineSnippets={[
-    {
-      code: `dependencies: [
-      .package(url: "https://github.com/TBD54566975/web5-swift", exact: "0.0.4"),
-]`,
-      language: 'Swift',
-    },
-  ]}
-/>
+<Dependencies languageDependencies={[
+  { language: 'javascript', dependencies: ['@web5/credentials', '@web5/dids', 'node-fetch'] },
+  { language: 'maven', dependencies: ['web5-credentials', 'web5-dids',  'io.ktor:ktor-client-cio:2.3.9', 'io.ktor:ktor-client-core:2.3.9', 'com.nimbusds:nimbus-jose-jwt:9.15.2'] },
+  { language: 'gradle', dependencies: ['web5-credentials', 'web5-dids',  'io.ktor:ktor-client-cio:2.3.9', 'io.ktor:ktor-client-core:2.3.9'] },
+  { language: 'swift', dependencies: ['Web5'] }
+]}/> 
 
 ### Framework Flexibility
 

--- a/site/docs/tbdex/issuer/vc-serverSetup.mdx
+++ b/site/docs/tbdex/issuer/vc-serverSetup.mdx
@@ -34,28 +34,11 @@ This example demonstrates how to use Express to set up the VC issuance service. 
 
 You'll also need to install `@web5/credentials` to create and issue credentials:
 
-<Shnip
-  snippets={[
-    {
-      snippetName: 'credentialIssuanceJsPackage',
-      language: 'JavaScript',
-      codeLanguage: 'bash',
-    },
-    {
-      language: 'Kotlin',
-      nestedSnippets: {
-        Gradle: {
-          snippetName: 'credentialIssuanceGradlePackage',
-          language: 'gradle',
-        },
-        Maven: {
-          snippetName: 'credentialIssuanceMavenPackage',
-          language: 'xml',
-        },
-      },
-    },
-  ]}
-/>
+<Dependencies languageDependencies={[
+  { language: 'javascript', dependencies: ['@web5/credentials'] },
+  { language: 'maven', dependencies: ['web5-credentials'] },
+  { language: 'gradle', dependencies: ['web5-credentials'] },
+]}/>
 
 ### Create a DID
 

--- a/site/docs/tbdex/pfi/required-sdks.mdx
+++ b/site/docs/tbdex/pfi/required-sdks.mdx
@@ -18,28 +18,11 @@ To implement and operate as a PFI, you’ll need to use the following SDKs:
 
 ## Install SDKs
 
-<Shnip
-  snippets={[
-    {
-      snippetName: 'pfiSdkInstallJs',
-      language: 'JavaScript',
-      codeLanguage: 'bash',
-    },
-    {
-      language: 'Kotlin',
-      nestedSnippets: {
-        Gradle: {
-          snippetName: 'pfiSdkInstallGradle',
-          language: 'gradle',
-        },
-        Maven: {
-          snippetName: 'pfiSdkInstallPom',
-          language: 'xml',
-        },
-      },
-    },
-  ]}
-/>
+<Dependencies languageDependencies={[
+  { language: 'javascript', dependencies: ['@web5/dids', '@web5/credentials', '@tbdex/http-server'] },
+  { language: 'maven', dependencies: ['tbdex'] },
+  { language: 'gradle', dependencies: ['tbdex'] },
+]}/>
 
 ## Import Classes
 

--- a/site/docs/tbdex/wallet/required-sdks.mdx
+++ b/site/docs/tbdex/wallet/required-sdks.mdx
@@ -19,33 +19,12 @@ To implement and operate as a Wallet on a tbDEX network, you’ll need to use th
 
 ## Install SDKs
 
-<Shnip 
-  snippets={[
-    { snippetName: 'walletSdkInstallJs', language: 'JavaScript', codeLanguage: 'bash',},
-    { 
-      nestedSnippets:{
-          'Gradle': {
-            "snippetName": 'walletSdkInstallGradle',
-            "language": 'gradle'
-          },
-          'Maven': {
-            "snippetName": 'walletSdkInstallPom',
-            "language": 'xml'
-          }
-        },
-        language: 'Kotlin'
-    }
-  ]}
-  inlineSnippets={[
-    {
-      code: `dependencies: [
-    .package(url: "https://github.com/TBD54566975/web5-swift", exact: "0.0.4"),
-    .package(url: "https://github.com/TBD54566975/tbdex-swift.git", branch: "main"),
-]`,
-      language: 'Swift',
-    },
-  ]}
-/>
+<Dependencies languageDependencies={[
+  { language: 'javascript', dependencies: ['@web5/dids', '@web5/credentials', '@tbdex/http-client'] },
+  { language: 'maven', dependencies: ['web5-credentials','web5-dids','tbdex'] },
+  { language: 'gradle', dependencies:['web5-credentials','web5-dids','tbdex'] },
+  { language: 'swift', dependencies: ['Web5', 'tbDex'] },
+]}/>
 
 <LanguageSwitchBlock>
   <div language="Kotlin">

--- a/site/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
+++ b/site/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
@@ -17,36 +17,12 @@ You can create a DID using any of the [Web5-supported DID methods](/docs/web5/le
 
 ## Install
 
-<Shnip
-  snippets={[
-    {
-      snippetName: 'createADidDependency',
-      language: "JavaScript",
-      codeLanguage: 'bash'
-    },
-    {
-      language: 'Kotlin',
-      nestedSnippets: {
-        Gradle: {
-          snippetName: 'createADidDependencyGradle',
-          language: 'gradle',
-        },
-        Maven: {
-          snippetName: 'createADidDependencyMaven',
-          language: 'xml',
-        },
-      },
-    }
-  ]}
-  inlineSnippets={[
-    {
-      code: `dependencies: [
-    .package(url: "https://github.com/TBD54566975/web5-swift", exact: "0.0.4"),
-]`,
-      language: 'Swift',
-    },
-  ]}
-/>
+<Dependencies languageDependencies={[
+  { language: 'javascript', dependencies: ['@web5/dids'] },
+  { language: 'maven', dependencies: ['web5-dids'] },
+  { language: 'gradle', dependencies: ['web5-dids'] },
+  {language: 'swift', dependencies: ['Web5']},
+]}/>
 
 ## Import
 

--- a/site/docs/web5/build/decentralized-identifiers/key-management.mdx
+++ b/site/docs/web5/build/decentralized-identifiers/key-management.mdx
@@ -34,36 +34,12 @@ Below is an example that uses `AwsKeyManager` for production environments, and `
 
 **Install Packages**
 
-<Shnip
-  inlineSnippets={[
-    {
-      code: `npm i @web5/crypto @web5/dids @web5/crypto-aws-kms`,
-      language: 'JavaScript',
-      codeLanguage: 'bash',
-    },
-    {
-      code: `dependencies: [
-    .package(url: "https://github.com/TBD54566975/web5-swift.git", branch: "main")
-]`,
-      language: 'Swift',
-    },
-  ]}
-  snippets={[
-    {
-      nestedSnippets:{
-          'Gradle': {
-            "snippetName": 'keyManagementDependencyGradle',
-            "language": 'gradle'
-          },
-          'Maven': {
-            "snippetName": 'keyManagementDependencyPom',
-            "language": 'xml'
-          }
-        },
-        language: 'Kotlin'
-    }
-  ]}
-/>
+<Dependencies languageDependencies={[
+  { language: 'javascript', dependencies: ['@web5/dids', '@web5/crypto', '@web5/crypto-aws-kms'] },
+  { language: 'maven', dependencies: ['web5-dids', 'web5-crypto'] },
+  { language: 'gradle', dependencies: ['web5-dids', 'web5-crypto'] },
+  { language: 'swift', dependencies: ['Web5']},
+]}/> 
 
 **Import Classes**
 

--- a/site/docs/web5/build/verifiable-credentials/fan-club-vc.mdx
+++ b/site/docs/web5/build/verifiable-credentials/fan-club-vc.mdx
@@ -16,24 +16,11 @@ In this tutorial, we'll learn how to use [verifiable credentials](/docs/web5/lea
 ## Setting the Stage
 Before we start issuing and verifying credentials, let's set up our environment by installing the <LanguageSwitchLink text='@web5/credentials' links='{"JavaScript": "https://www.npmjs.com/package/@web5/credentials", "Kotlin": "https://mvnrepository.com/artifact/xyz.block/web5-credentials"}'/> and <LanguageSwitchLink text='@web5/dids' links='{"JavaScript": "https://www.npmjs.com/package/@web5/dids", "Kotlin": "https://mvnrepository.com/artifact/xyz.block/web5-dids"}'/> packages:
 
-<Shnip
-   snippets={[
-    { snippetName: 'fanClubSdkInstallJs', language: 'JavaScript', codeLanguage: 'bash'},
-    {
-      language: 'Kotlin',
-      nestedSnippets:{
-          'Gradle': {
-            "snippetName": 'fanClubSdkInstallGradle',
-            "language": 'gradle'
-          },
-          'Maven': {
-            "snippetName": 'fanClubSdkInstallPom',
-            "language": 'xml'
-          }
-        }
-    }
-    ]}
-/>
+<Dependencies languageDependencies={[
+  { language: 'javascript', dependencies: ['@web5/credentials', '@web5/dids'] },
+  { language: 'maven', dependencies: ['web5-credentials', 'web5-dids'] },
+  { language: 'gradle', dependencies: ['web5-credentials', 'web5-dids'] },
+]}/> 
 
 ### Import packages
 

--- a/site/docs/web5/build/verifiable-credentials/vc-issuance.mdx
+++ b/site/docs/web5/build/verifiable-credentials/vc-issuance.mdx
@@ -15,24 +15,11 @@ This guide provides a step-by-step process for issuing a [verifiable credential 
 
 **Install Packages**
 
-<Shnip
-   snippets={[
-    { snippetName: 'vcSdkInstallJs', language: 'JavaScript', codeLanguage: 'bash'},
-    {
-      language: 'Kotlin',
-      nestedSnippets:{
-          'Gradle': {
-            "snippetName": 'vcSdkInstallGradle',
-            "language": 'gradle'
-          },
-          'Maven': {
-            "snippetName": 'vcSdkInstallPom',
-            "language": 'xml'
-          }
-        }
-    }
-    ]}
-/>
+<Dependencies languageDependencies={[
+  { language: 'javascript', dependencies: ['@web5/credentials'] },
+  { language: 'maven', dependencies: ['web5-credentials'] },
+  { language: 'gradle', dependencies: ['web5-credentials'] },
+]}/> 
 
 **Install Classes**
 

--- a/site/src/components/Dependencies.jsx
+++ b/site/src/components/Dependencies.jsx
@@ -13,6 +13,13 @@ const languageMap = {
 };
 
 function Dependencies({ languageDependencies }) {
+  const mavenDependencies =
+    languageDependencies.find(({ language }) => language === 'maven')
+      ?.dependencies || [];
+  const gradleDependencies =
+    languageDependencies.find(({ language }) => language === 'gradle')
+      ?.dependencies || [];
+
   return (
     <>
       <LanguageTabBar />
@@ -21,11 +28,13 @@ function Dependencies({ languageDependencies }) {
           if (language === 'maven' || language === 'gradle') {
             return (
               <div key={language} language={languageMap[language]}>
-                <KotlinDependencies dependencies={dependencies} />
+                <KotlinDependencies
+                  mavenDependencies={mavenDependencies}
+                  gradleDependencies={gradleDependencies}
+                />
               </div>
             );
           } else {
-            console.log('language', language)
             return (
               <div language={languageMap[language]}>
                 <Dependency language={language} dependencies={dependencies} />
@@ -38,11 +47,18 @@ function Dependencies({ languageDependencies }) {
   );
 }
 
-function KotlinDependencies({ dependencies }) {
-
+function KotlinDependencies({ mavenDependencies, gradleDependencies }) {
   const kotlinDependencies = [
-    <Dependency key="Gradle" language="gradle" dependencies={dependencies} />,
-    <Dependency key="Maven" language="maven" dependencies={dependencies} />,
+    <Dependency
+      key="Gradle"
+      language="gradle"
+      dependencies={gradleDependencies}
+    />,
+    <Dependency
+      key="Maven"
+      language="maven"
+      dependencies={mavenDependencies}
+    />,
   ];
   return <BreadcrumbTab dependencies={kotlinDependencies} />;
 }

--- a/site/src/components/Dependency.jsx
+++ b/site/src/components/Dependency.jsx
@@ -4,106 +4,131 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import CodeBlock from '@theme/CodeBlock';
 import BreadcrumbTab from '@site/src/components/BreadcrumbTab';
 
-
 function GradleDependencies({ dependencies, sdks }) {
   const repositoriesBlock = `repositories {
     mavenCentral()
-    maven("https://repo.danubetech.com/repository/maven-public/")
+    maven {
+      name = "tbd-oss-thirdparty"
+      url = uri("https://blockxyz.jfrog.io/artifactory/tbd-oss-thirdparty-maven2/")
+      mavenContent {
+        releasesOnly()
+    }
   }`;
 
-  // Generate the implementation lines
-  const dependenciesBlock = dependencies.map(dep => {
-    return `    implementation("xyz.block:${dep}:${sdks[dep]}")`; // Note the added indentation
-  }).join('\n');
+  const dependenciesBlock = dependencies
+    .map((dep) => {
+      const version = sdks[dep];
+      if (version) {
+        return `    implementation("xyz.block:${dep}:${version}")`;
+      } else {
+        return `    implementation("${dep}")`;
+      }
+    })
+    .join('\n');
 
-  // Wrap the implementation lines in a `dependencies` block
   const gradleDependenciesBlock = `dependencies {\n${dependenciesBlock}\n}`;
-
-  // Combine repositories and dependencies blocks
   const gradleString = `${repositoriesBlock}\n${gradleDependenciesBlock}`;
 
   return <CodeBlock language="gradle">{gradleString}</CodeBlock>;
 }
 
-
 function MavenDependencies({ dependencies, sdks }) {
-  const repositoriesBlock = dependencies.map(dep => {
-    return `
-        <repository>
-            <id>mavenCentral</id>
-            <url>https://repo1.maven.org/maven2/</url>
-        </repository>
-    `;
-  }).join('\n');
-
-  const dependenciesBlock = dependencies.map(dep => {
-    return `
-        <dependency>
-            <groupId>xyz.block</groupId>
-            <artifactId>${dep}</artifactId>
-            <version>${sdks[dep]}</version>
-        </dependency>
-    `;
-  }).join('\n');
-
-  const mavenString = `
-<repositories>
-${repositoriesBlock}
-</repositories>
-
-<dependencies>
-${dependenciesBlock}
-</dependencies>
+  const repositoriesBlock = `
+ <repository>
+      <id>tbd-oss-thirdparty</id>
+      <name>tbd-oss-thirdparty</name>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <url>https://blockxyz.jfrog.io/artifactory/tbd-oss-thirdparty-maven2/</url>
+</repository>
   `;
+
+  const dependenciesBlock = dependencies
+    .map((dep) => {
+      let [groupId, artifactId, version] = dep.split(':');
+      if (!version) {
+        // Handle the case where the version isn't part of the split
+        version = sdks[dep];
+        groupId = 'xyz.block';
+        artifactId = dep;
+      }
+      return `
+<dependency>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+</dependency>`;
+    })
+    .join('');
+
+  const mavenString = `<repositories>${repositoriesBlock}</repositories>\n<dependencies>${dependenciesBlock}</dependencies>`;
 
   return <CodeBlock language="xml">{mavenString}</CodeBlock>;
 }
 
 function SwiftDependencies({ dependencies, sdkVersions }) {
-  const swiftImports = dependencies.map((dep, index) => {
-    const packageInfo = sdkVersions.swift[dep];
-    if (!packageInfo) {
-      console.error(`Package "${dep}" not found in sdkVersions.swift`);
-      return null;
-    }
-    const { url, branch } = packageInfo;
-    return `    .package(url: "${url}", branch: "${branch}")`;
-  }).filter(Boolean).join(',\n');
+  const swiftImports = dependencies
+    .map((dep, index) => {
+      const packageInfo = sdkVersions.swift[dep];
+      if (!packageInfo) {
+        console.error(`Package "${dep}" not found in sdkVersions.swift`);
+        return null;
+      }
+      const { url, branch } = packageInfo;
+      return `    .package(url: "${url}", branch: "${branch}")`;
+    })
+    .filter(Boolean)
+    .join(',\n');
 
   const swiftDependenciesString = `dependencies: [\n${swiftImports}\n]`;
 
   return <CodeBlock language="swift">{swiftDependenciesString}</CodeBlock>;
 }
 
-
 // Function to render npm install commands
-function InstallCommands({ dependencies }) {
-  const commandString = dependencies.map(dep => `npm install ${dep}`).join('\r\n');
+function InstallCommands({ dependencies, sdkVersions }) {
+  const commandString = dependencies
+    .map((dep) => {
+      const normalizedDep = dep.startsWith('@') ? dep : `@${dep}`;
+      const version = sdkVersions[normalizedDep];
+      if (version) {
+        return `npm install ${normalizedDep}@${version}`;
+      } else {
+        return `npm install ${normalizedDep}`;
+      }
+    })
+    .join('\n');
+
   return <CodeBlock language="bash">{commandString}</CodeBlock>;
 }
 
 // Function to render JavaScript package.json
 function PackageJson({ sdkVersions, dependencies }) {
-  const requiredDependencies = Object.entries(dependencies).reduce((acc, [dep, depName]) => {
-    const depVersion = sdkVersions.js[depName];
-    acc[depName] = depVersion;
-    return acc;
-  }, { type: 'module' });
+  const requiredDependencies = Object.entries(dependencies).reduce(
+    (acc, [dep, depName]) => {
+      const depVersion = sdkVersions.js[depName];
+      acc[depName] = depVersion;
+      return acc;
+    },
+    { type: 'module' },
+  );
 
   const jsonString = JSON.stringify(requiredDependencies, null, 2);
   return <CodeBlock language="js">{jsonString}</CodeBlock>;
 }
 
 function JvmDependencies({ dependencies, sdks, language }) {
-  if(language === 'gradle') {
-
-   return <GradleDependencies dependencies={dependencies} sdks={sdks} />
+  if (language === 'gradle') {
+    return <GradleDependencies dependencies={dependencies} sdks={sdks} />;
   }
 
   if (language === 'maven') {
-    return <MavenDependencies dependencies={dependencies} sdks={sdks} />
+    return <MavenDependencies dependencies={dependencies} sdks={sdks} />;
   }
-
 }
 
 // Main Dependencies component
@@ -111,32 +136,49 @@ function Dependency({ language, dependencies, display = 'install' }) {
   const {
     siteConfig: { customFields },
   } = useDocusaurusContext();
-  
+
   const { SDK_VERSIONS } = customFields;
-  
+
   switch (display) {
     case 'install':
       switch (language) {
         case 'javascript':
-          return <InstallCommands dependencies={dependencies} />;
+          return (
+            <InstallCommands
+              dependencies={dependencies}
+              sdkVersions={SDK_VERSIONS.js}
+            />
+          );
         case 'gradle':
         case 'maven':
-          return <JvmDependencies language={language} dependencies={dependencies} sdks={SDK_VERSIONS.jvm} />;
+          return (
+            <JvmDependencies
+              language={language}
+              dependencies={dependencies}
+              sdks={SDK_VERSIONS.jvm}
+            />
+          );
         case 'swift':
-          return <SwiftDependencies sdkVersions={SDK_VERSIONS} dependencies={dependencies} />;
+          return (
+            <SwiftDependencies
+              sdkVersions={SDK_VERSIONS}
+              dependencies={dependencies}
+            />
+          );
         default:
           return null; // Handle unsupported languages
       }
     default:
   }
-  
+
   switch (language) {
     case 'javascript':
-      return <PackageJson sdkVersions={SDK_VERSIONS} dependencies={dependencies} />;
+      return (
+        <PackageJson sdkVersions={SDK_VERSIONS} dependencies={dependencies} />
+      );
     default:
-      return null; 
+      return null;
   }
-
 }
 
 export default Dependency;


### PR DESCRIPTION
Nick made a Dependency component to dynamic render dependency versions in docs. This PR uses that Dependency component, so we're not hardcoding. I also edited the Dependency component to cover the following cases:
- we're using dependencies that aren't part of our SDK like node-fetch
- we need to add versions for JS imports
- gradle and maven sometimes don't have the same imports
- we have our own third party repo for kotlin called this ("https://blockxyz.jfrog.io/artifactory/tbd-oss-thirdparty-maven2/")


This pull request includes changes to the code snippets in the documentation, replacing the previous `Shnip` component with a new `Dependencies` component. This change simplifies the presentation of dependencies in multiple programming languages (JavaScript, Kotlin, Swift) and different package managers (npm, Gradle, Maven). It also modifies the `Dependency.jsx` and `Dependencies.jsx` files to support these changes.

Here are the most important changes:

**Changes to Documentation:**

* [`site/docs/tbdex/issuer/kcc/kcc-wallet.mdx`](diffhunk://#diff-551ad78123404e8b183b18868e2a4debb23e81322b3038234332ca7034ee9603L31-R36): Replaced the `Shnip` component with the `Dependencies` component to list the required dependencies for the Wallet App.
* [`site/docs/tbdex/issuer/vc-serverSetup.mdx`](diffhunk://#diff-a6eed794ddc900bbb72c9950bcf2a34d4d24f742fc8c19da8cecb84dbd29801aL37-R41): Updated the dependencies required to set up the VC issuance service using Express.
* [`site/docs/tbdex/pfi/required-sdks.mdx`](diffhunk://#diff-0f824cb54145c6fb8c821f0f396fede35a2e81026134d28402dfbb5e924ad129L21-R25): Changed the way SDKs are installed for implementing and operating as a PFI.
* [`site/docs/tbdex/wallet/required-sdks.mdx`](diffhunk://#diff-90be7ee1ee51551281a7941f503e1ddbf6a31b572ca48da7c76245fdca7ffa21L22-R27): Modified the installation of SDKs for implementing and operating as a Wallet on a tbDEX network.
* [`site/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx`](diffhunk://#diff-bae5f20e432b6db875d437eacc0d8f6cd268c7e68f6b95afdc3bd77c46320895L20-R25): Changed the installation of dependencies for creating a DID.
* [`site/docs/web5/build/verifiable-credentials/fan-club-vc.mdx`](diffhunk://#diff-40328f90cfa206a8289747b79aa9064573176efe4e7c21750fbbd672bf915590L19-R23): Updated the installation of dependencies for issuing and verifying credentials.

**Changes to Components:**

* [`site/src/components/Dependencies.jsx`](diffhunk://#diff-f999a96d6c282caf53c57ef4e3ebb272aa03d567d5185f668e74870e08983f07R16-R22): Modified the `Dependencies` function to handle Maven and Gradle dependencies separately. Also updated the `KotlinDependencies` function to pass Maven and Gradle dependencies separately. [[1]](diffhunk://#diff-f999a96d6c282caf53c57ef4e3ebb272aa03d567d5185f668e74870e08983f07R16-R22) [[2]](diffhunk://#diff-f999a96d6c282caf53c57ef4e3ebb272aa03d567d5185f668e74870e08983f07L24-L28) [[3]](diffhunk://#diff-f999a96d6c282caf53c57ef4e3ebb272aa03d567d5185f668e74870e08983f07L41-R61)
* [`site/src/components/Dependency.jsx`](diffhunk://#diff-c8958ec0db26349277de071c29fe4a019803f9fe25b17f3033eb28a52d7a3b95L7-L106): Updated the `GradleDependencies`, `MavenDependencies`, `InstallCommands`, `PackageJson`, `JvmDependencies`, and `Dependency` functions to handle the new format of dependencies. [[1]](diffhunk://#diff-c8958ec0db26349277de071c29fe4a019803f9fe25b17f3033eb28a52d7a3b95L7-L106) [[2]](diffhunk://#diff-c8958ec0db26349277de071c29fe4a019803f9fe25b17f3033eb28a52d7a3b95L121-R167) [[3]](diffhunk://#diff-c8958ec0db26349277de071c29fe4a019803f9fe25b17f3033eb28a52d7a3b95L135-L139)