### PR TITLE
quick fix - update package

### DIFF
--- a/site/docs/tbdex/pfi/required-sdks.mdx
+++ b/site/docs/tbdex/pfi/required-sdks.mdx
@@ -10,11 +10,11 @@ hide_title: true
 
 To implement and operate as a PFI, you’ll need to use the following SDKs:
 
-- **web5/dids** - To work with [Decentralized Identifiers (DID)](/docs/web5/learn/decentralized-identifiers), including creating an identity, and performing any other required cryptographic functions, you’ll need this package. Check out [Key Management Service](/docs/web5/build/decentralized-identifiers/key-management) for DIDs in production environments.
+- **@web5/dids** - To work with [Decentralized Identifiers (DID)](/docs/web5/learn/decentralized-identifiers), including creating an identity, and performing any other required cryptographic functions, you’ll need this package. Check out [Key Management Service](/docs/web5/build/decentralized-identifiers/key-management) for DIDs in production environments.
 
-- **web5/credentials** - Enable verification of your customer information, including information such as customer’s identity or whether a customer is on a sanctions list. [Verifiable Credentials (VC)](/docs/web5/learn/verifiable-credentials) provide a decentralized and trustworthy way of verifying a customer.
+- **@web5/credentials** - Enable verification of your customer information, including information such as customer’s identity or whether a customer is on a sanctions list. [Verifiable Credentials (VC)](/docs/web5/learn/verifiable-credentials) provide a decentralized and trustworthy way of verifying a customer.
 
-- **tbdex/server** - Enable convenience methods for setting up routing and networking to facilitate your PFI.
+- **@tbdex/http-server** - Enable convenient methods for setting up routing and networking to facilitate your PFI.
 
 ## Install SDKs
 


### PR DESCRIPTION
This pull request includes updates to the SDK package names in the `site/docs/tbdex/pfi/required-sdks.mdx` file. The changes are mainly renaming the packages with the correct names and providing more accurate descriptions.

* [`site/docs/tbdex/pfi/required-sdks.mdx`](diffhunk://#diff-0f824cb54145c6fb8c821f0f396fede35a2e81026134d28402dfbb5e924ad129L13-R17): Updated the SDK package names from `web5/dids` to `@web5/dids`, `web5/credentials` to `@web5/credentials`, and `tbdex/server` to `@tbdex/http-server`. Also, the description for the `@tbdex/http-server` package was slightly modified to better describe its functionality.