### PR TITLE
Set pw for web5 connect

### DIFF
--- a/site/testsuites/testsuite-javascript/__tests__/setup-web5.js
+++ b/site/testsuites/testsuite-javascript/__tests__/setup-web5.js
@@ -11,15 +11,24 @@ const testDwnUrl = import.meta.env.VITE_APP_TEST_DWN_URL;
 import { Web5IdentityAgent } from '@web5/identity-agent';
 
 export const setUpWeb5 = async () => {
+  const testDwnUrl = import.meta.env.VITE_APP_TEST_DWN_URL;
+  const password = 'rizel-made-this-password-replace-this'; 
+
   const dwnOptions = testDwnUrl
     ? {
-        techPreview: {
-          dwnEndpoints: ['http://localhost:3000'],
-        },
-      }
+      techPreview: {
+        dwnEndpoints: ['http://localhost:3000'],
+      },
+    }
     : undefined;
 
-  const { web5, did } = await Web5.connect(dwnOptions);
+  let options = { password: password };
+
+  if (dwnOptions) {
+    options.techPreview = dwnOptions.techPreview;
+  }
+
+  const { web5, did } = await Web5.connect(options);
 
   globalThis.web5 = web5;
   globalThis.did = did;

--- a/site/testsuites/testsuite-javascript/__tests__/setup-web5.js
+++ b/site/testsuites/testsuite-javascript/__tests__/setup-web5.js
@@ -11,7 +11,7 @@ const testDwnUrl = import.meta.env.VITE_APP_TEST_DWN_URL;
 import { Web5IdentityAgent } from '@web5/identity-agent';
 
 export const setUpWeb5 = async () => {
-  const password = 'rizel-made-this-password-replace-this'; 
+  const password = 'super-secret-test-password'; 
 
   const dwnOptions = testDwnUrl
     ? {

--- a/site/testsuites/testsuite-javascript/__tests__/setup-web5.js
+++ b/site/testsuites/testsuite-javascript/__tests__/setup-web5.js
@@ -11,7 +11,6 @@ const testDwnUrl = import.meta.env.VITE_APP_TEST_DWN_URL;
 import { Web5IdentityAgent } from '@web5/identity-agent';
 
 export const setUpWeb5 = async () => {
-  const testDwnUrl = import.meta.env.VITE_APP_TEST_DWN_URL;
   const password = 'rizel-made-this-password-replace-this'; 
 
   const dwnOptions = testDwnUrl


### PR DESCRIPTION
I think @leordev might be able to help me set an actual password. Perhaps, this can be stored in GitHub secrets or some kind of dot env file, and then used in GitHub actions. I don't have access to the GitHub secrets tabs nor do I know how we handle environment variables in our app, so for now I hard coded the password.

This should remove the warning: ` SECURITY WARNING: You have not set a password, which defaults to a static, guessable value. This significantly compromises the security of your data. Please configure a secure, unique password.`

## What type of PR is this? (check all applicable)

- [x] ♻️ Refactor

## Description

This pull request includes changes to the `setUpWeb5` function in the `site/testsuites/testsuite-javascript/__tests__/setup-web5.js` file. The changes introduce a password for the Web5 connection and modify the connection options to include this password.

The most important changes are:

* [`site/testsuites/testsuite-javascript/__tests__/setup-web5.js`](diffhunk://#diff-b30a7bc904f97e73a67fbd13119f3922253c6c0e3dca37460b2861e20656a633R14-R15): Added a password for the Web5 connection. This password is currently a placeholder and should be replaced with a secure password.
* [`site/testsuites/testsuite-javascript/__tests__/setup-web5.js`](diffhunk://#diff-b30a7bc904f97e73a67fbd13119f3922253c6c0e3dca37460b2861e20656a633L22-R30): Modified the connection options for the Web5 connection. If `dwnOptions` is defined, its `techPreview` property is added to the options. The password is also included in the options.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207080853489279