### PR TITLE
[Quickfix] Update docs for sharedTodo example

### DIFF
--- a/examples/tutorials/shared-todo-completed/pages/todos/[id].vue
+++ b/examples/tutorials/shared-todo-completed/pages/todos/[id].vue
@@ -147,7 +147,7 @@ async function addTodo() {
             protocolPath: 'list/todo',
             schema: protocolDefinition.types.todo.schema,
             dataFormat: protocolDefinition.types.todo.dataFormats[0],
-            parentContextId
+            parentContextId: listId.value
         }
     });
 

--- a/examples/tutorials/shared-todo-completed/pages/todos/[id].vue
+++ b/examples/tutorials/shared-todo-completed/pages/todos/[id].vue
@@ -147,8 +147,7 @@ async function addTodo() {
             protocolPath: 'list/todo',
             schema: protocolDefinition.types.todo.schema,
             dataFormat: protocolDefinition.types.todo.dataFormats[0],
-            parentId: listId.value,
-            contextId: listId.value,
+            parentContextId
         }
     });
 

--- a/site/docs/web5/build/apps/shared-todo-app.mdx
+++ b/site/docs/web5/build/apps/shared-todo-app.mdx
@@ -526,8 +526,7 @@ async function addTodo() {
             protocolPath: 'list/todo',
             schema: protocolDefinition.types.todo.schema,
             dataFormat: protocolDefinition.types.todo.dataFormats[0],
-            parentId: listId.value,
-            contextId: listId.value,
+            parentContextId: listId.value,
         }
     });
 

--- a/site/docs/web5/learn/protocols.md
+++ b/site/docs/web5/learn/protocols.md
@@ -346,8 +346,7 @@ const replyResponse = await web5.dwn.records.create({
       protocol: protocolDefinition.protocol,
       protocolPath: 'post/reply',
       //highlight-next-line
-      parentId: postRecord.id,
-      contextId: postRecord.contextId,
+      parentContextId: postRecord.id,
       schema: "https://social-media.xyz/schemas/replySchema",
       dataFormat: 'text/plain',
     },

--- a/site/docs/web5/troubleshooting/common-errors.mdx
+++ b/site/docs/web5/troubleshooting/common-errors.mdx
@@ -71,7 +71,7 @@ await web5.dwn.records.create({
     protocolPath: 'list/todo',
     schema: protocolDefinition.types.todo.schema,
     dataFormat: protocolDefinition.types.todo.dataFormats[0],
-    parentId: listId.value,
+    parentContextId: listId.value,
   },
 });
 ```


### PR DESCRIPTION
This pull request includes changes in two files, `examples/tutorials/shared-todo-completed/pages/todos/[id].vue` and `site/docs/web5/build/apps/shared-todo-app.mdx`. Both changes are in the `async function addTodo() {` and involve modifying the properties of an object passed to a function call. The `parentId` and `contextId` properties have been replaced with a single `parentContextId` property.

Changes:

* `examples/tutorials/shared-todo-completed/pages/todos/[id].vue`: In the `async function addTodo() {`, the `parentId` and `contextId` properties have been replaced with a single `parentContextId` property. ([examples/tutorials/shared-todo-completed/pages/todos/[id].vueL150-R150](diffhunk://#diff-a0b1cc637d3572c9bdd047138840340f4bd7490fe9b487c5057aecaf6e45769eL150-R150))
* [`site/docs/web5/build/apps/shared-todo-app.mdx`](diffhunk://#diff-bdf4ea718f3dabac44ef489b892051758c97226476274906b21787a635edfd6bL529-R529): In the `async function addTodo() {`, the `parentId` and `contextId` properties have been replaced with a `parentContextId` property, which is assigned the value of `listId.value`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207069925518835