### PR TITLE
Upgrading @web5/api to 0.9.2

### DIFF
--- a/examples/tutorials/book-reviews/package.json
+++ b/examples/tutorials/book-reviews/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@web5/api": "0.9.1"
+    "@web5/api": "0.9.2"
   },
   "type": "module"
 }

--- a/examples/tutorials/dinger-completed/package.json
+++ b/examples/tutorials/dinger-completed/package.json
@@ -11,7 +11,7 @@
     "test:browser": "start-server-and-test dev http://localhost:8081 test"
   },
   "dependencies": {
-    "@web5/api": "0.9.1",
+    "@web5/api": "0.9.2",
     "buffer": "^6.0.3",
     "crypto-browserify": "3.12.0",
     "next": "13.5.4",

--- a/examples/tutorials/dinger-starter/package.json
+++ b/examples/tutorials/dinger-starter/package.json
@@ -11,7 +11,7 @@
     "test:browser": "start-server-and-test dev http://localhost:8080 test"
   },
   "dependencies": {
-    "@web5/api": "0.9.1",
+    "@web5/api": "0.9.2",
     "crypto-browserify": "3.12.0",
     "next": "13.5.4",
     "process": "0.11.10",

--- a/examples/tutorials/fan-club-credential/package.json
+++ b/examples/tutorials/fan-club-credential/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@web5/api": "0.9.1",
+    "@web5/api": "0.9.2",
     "@web5/credentials": "1.0.0",
     "@web5/dids": "1.0.0",
     "@web5/user-agent": "0.3.1"

--- a/examples/tutorials/shared-todo-completed/package.json
+++ b/examples/tutorials/shared-todo-completed/package.json
@@ -24,7 +24,7 @@
     "@heroicons/vue": "1.0.6",
     "@nuxt/kit": "3.8.2",
     "@nuxt/ui-templates": "1.3.1",
-    "@web5/api": "0.9.1",
+    "@web5/api": "0.9.2",
     "vite-plugin-node-stdlib-browser": "0.2.1",
     "vue": "3.3.4",
     "vue-router": "4.2.5"

--- a/examples/tutorials/shared-todo-starter/package.json
+++ b/examples/tutorials/shared-todo-starter/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@heroicons/vue": "1.0.6",
     "@nuxt/ui-templates": "1.3.1",
-    "@web5/api": "0.9.1",
+    "@web5/api": "0.9.2",
     "vue": "3.3.4",
     "vue-router": "4.2.5"
   }

--- a/examples/tutorials/todo-completed/package.json
+++ b/examples/tutorials/todo-completed/package.json
@@ -20,7 +20,7 @@
     "varint": "6.0.0",
     "vue": "3.2.41",
     "vue-toastification": "2.0.0-rc.5",
-    "@web5/api": "0.9.1",
+    "@web5/api": "0.9.2",
     "vue-router": "4.2.5"
   },
   "devDependencies": {

--- a/examples/tutorials/todo-starter/package.json
+++ b/examples/tutorials/todo-starter/package.json
@@ -20,7 +20,7 @@
     "varint": "6.0.0",
     "vue": "3.3.4",
     "vue-toastification": "2.0.0-rc.5",
-    "@web5/api": "0.9.1"
+    "@web5/api": "0.9.2"
   },
   "devDependencies": {
     "@esbuild-plugins/node-globals-polyfill": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@tbdex/http-client": "1.0.0",
     "@tbdex/http-server": "1.0.0",
     "@tbdex/protocol": "1.0.0",
-    "@web5/api": "0.9.1",
+    "@web5/api": "0.9.2",
     "@web5/credentials": "1.0.0",
     "@web5/crypto": "1.0.0",
     "@web5/crypto-aws-kms": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       '@web5/api':
-        specifier: 0.9.1
-        version: 0.9.1
+        specifier: 0.9.2
+        version: 0.9.2
       '@web5/credentials':
         specifier: 1.0.0
         version: 1.0.0
@@ -160,14 +160,14 @@ importers:
   examples/tutorials/book-reviews:
     dependencies:
       '@web5/api':
-        specifier: 0.9.1
-        version: 0.9.1
+        specifier: 0.9.2
+        version: 0.9.2
 
   examples/tutorials/dinger-completed:
     dependencies:
       '@web5/api':
-        specifier: 0.9.1
-        version: 0.9.1
+        specifier: 0.9.2
+        version: 0.9.2
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -193,8 +193,8 @@ importers:
   examples/tutorials/dinger-starter:
     dependencies:
       '@web5/api':
-        specifier: 0.9.1
-        version: 0.9.1
+        specifier: 0.9.2
+        version: 0.9.2
       crypto-browserify:
         specifier: 3.12.0
         version: 3.12.0
@@ -217,8 +217,8 @@ importers:
   examples/tutorials/fan-club-credential:
     dependencies:
       '@web5/api':
-        specifier: 0.9.1
-        version: 0.9.1
+        specifier: 0.9.2
+        version: 0.9.2
       '@web5/credentials':
         specifier: 1.0.0
         version: 1.0.0
@@ -241,8 +241,8 @@ importers:
         specifier: 1.3.1
         version: 1.3.1
       '@web5/api':
-        specifier: 0.9.1
-        version: 0.9.1
+        specifier: 0.9.2
+        version: 0.9.2
       vite-plugin-node-stdlib-browser:
         specifier: 0.2.1
         version: 0.2.1(node-stdlib-browser@1.2.0)(rollup@2.61.1)(vite@5.1.4)
@@ -287,8 +287,8 @@ importers:
         specifier: 1.3.1
         version: 1.3.1
       '@web5/api':
-        specifier: 0.9.1
-        version: 0.9.1
+        specifier: 0.9.2
+        version: 0.9.2
       vue:
         specifier: 3.3.4
         version: 3.3.4
@@ -339,8 +339,8 @@ importers:
         specifier: 9.6.0
         version: 9.6.0(vue@3.2.41)
       '@web5/api':
-        specifier: 0.9.1
-        version: 0.9.1
+        specifier: 0.9.2
+        version: 0.9.2
       multiformats:
         specifier: 10.0.2
         version: 10.0.2
@@ -415,8 +415,8 @@ importers:
         specifier: 9.6.0
         version: 9.6.0(vue@3.3.4)
       '@web5/api':
-        specifier: 0.9.1
-        version: 0.9.1
+        specifier: 0.9.2
+        version: 0.9.2
       multiformats:
         specifier: 10.0.2
         version: 10.0.2
@@ -7332,8 +7332,8 @@ packages:
       - supports-color
     dev: false
 
-  /@web5/api@0.9.1:
-    resolution: {integrity: sha512-P0vKf7Jn3yuy4g/P6rUgJx2gLG5fwCmLQXa1eGCS8KJ+J6ZK/Qx0/FEnNo2mDcooBk8esxO3FVB+93p5nXcpgw==}
+  /@web5/api@0.9.2:
+    resolution: {integrity: sha512-GZHrTst0Pp7t1U1F0zLDUuI78v5rPGdMsgG0RMKd85eJtXHhCIBfNHjit7Z14epKKHmDfugYULB7SEI7SCljXg==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@web5/agent': 0.3.1

--- a/sdk-versions.json
+++ b/sdk-versions.json
@@ -3,7 +3,7 @@
     "@tbdex/http-client": "1.0.0",
     "@tbdex/http-server": "1.0.0",
     "@tbdex/protocol": "1.0.0",
-    "@web5/api": "0.9.1",
+    "@web5/api": "0.9.2",
     "@web5/credentials": "1.0.0",
     "@web5/crypto": "1.0.0",
     "@web5/crypto-aws-kms": "1.0.0",


### PR DESCRIPTION
Small bug fix happened and web5/api 0.9.2 was released, so I opened a PR to upgrade the dev site to 0.9.2. 

Is there more I need to do 🤔 ?