### PR TITLE
Propagate packagejson

### DIFF
--- a/propagateSdkVersions.js
+++ b/propagateSdkVersions.js
@@ -11,8 +11,6 @@ const directoriesToUpdate = [
   path.resolve(__dirname, "./site/testsuites"),
 ];
 
-console.log("directories", directoriesToUpdate);
-
 const parseString = util.promisify(xml2js.parseString);
 const builder = new xml2js.Builder();
 

--- a/propagateSdkVersions.js
+++ b/propagateSdkVersions.js
@@ -11,6 +11,8 @@ const directoriesToUpdate = [
   path.resolve(__dirname, "./site/testsuites"),
 ];
 
+console.log("directories", directoriesToUpdate);
+
 const parseString = util.promisify(xml2js.parseString);
 const builder = new xml2js.Builder();
 


### PR DESCRIPTION
This fixes the propagate sdk-versions script so that pom.xml is updated by regex instead of using a parser.