### PR TITLE
`did:dht` Republish Warning 

### DIFF
--- a/site/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
+++ b/site/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
@@ -57,6 +57,9 @@ The following DID methods are supported:
   ]}
 />
 
+:::danger Important: Weekly Republishing Required for `did:dht` DIDs
+**Temporarily** DIDs created using the `did:dht` method **must** be republished weekly to prevent them from becoming unresolvable. An automatic republishing feature will be integrated into the SDK in the coming weeks.
+:::
 
 ### did\:jwk
 

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did.test.js
@@ -59,6 +59,9 @@ import { DidJwk } from '@web5/dids'
     // DID Document
     const didDocument = JSON.stringify(didDht.document);
 
+    // Republish DID 
+    const republishedDid = await DidDht.publish({did: didDht});
+
     // :snippet-end:
 
     expect(did).toMatch(/^did:dht:/);

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.kt
@@ -27,6 +27,9 @@ internal class HowToCreateDidTest {
 
     //DID Document
     val didDocument = portableDid.didDocument
+
+    //Republish DID
+    val republishedDid = DidDht.publish(didDht)
     // :snippet-end:
 
     assertNotNull(did, "DID should not be null")

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.kt
@@ -28,8 +28,10 @@ internal class HowToCreateDidTest {
     //DID Document
     val didDocument = portableDid.didDocument
 
-    //Republish DID
-    val republishedDid = DidDht.publish(didDht)
+    //Republish Did
+    DidDht.publish( didDht.keyManager, didDht.document )
+
+
     // :snippet-end:
 
     assertNotNull(did, "DID should not be null")


### PR DESCRIPTION
Until republish feature is added into the sdks, `did:dht` will need to be republished weekly


## Direct Link To Preview: 

https://deploy-preview-1400--tbd-website-developer.netlify.app/docs/web5/build/decentralized-identifiers/how-to-create-did#diddht