### PR TITLE
removing `updateADidWithAServiceEndpointKT` snippet

### DIFF
--- a/site/docs/tbdex/issuer/vc-serverSetup.mdx
+++ b/site/docs/tbdex/issuer/vc-serverSetup.mdx
@@ -69,11 +69,13 @@ If you have an existing DID you'll need to update that DID Document with an IDV 
       snippetName: 'updateADidWithServiceEndpointJS',
       language: 'JavaScript',
       title: 'did.js',
-    },
+    }
+  ]}
+  inlineSnippets={[
     {
-      snippetName: 'updateADidWithAServiceEndpointKT',
+      code: `Updating a DID Document with a service endpoint is not currently supported in Kotlin.`,
       language: 'Kotlin',
-      title: 'Application.kt',
+      codeLanguage: 'text',
     },
   ]}
 />

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/credentialIssuance.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/credentialIssuance.test.js
@@ -164,7 +164,6 @@ describe('Sanctions Credential Issuance', () => {
     });
     
     const updatedDocument = await DidDht.publish({ did: issuerBearerDid });
-    console.log(updatedDocument)
 
     expect(updatedDocument.didDocument).toHaveProperty('service');
   });

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/credentialIssuance.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/credentialIssuance.test.js
@@ -46,16 +46,6 @@ const issuerBearerDid = await DidDht.create({
 });
 // :snippet-end:
 
-// :snippet-start: updateADidWithServiceEndpointJS
-issuerBearerDid.document.service.push({
-  id: 'idv',
-  type: 'IDV',
-  serviceEndpoint: 'https://exampleIdvEndpoint.com/idv/siopv2/initiate',
-});
-
-await DidDht.publish({ did: issuerBearerDid });
-// :snippet-end:
-
 const app = express();
 app.use(express.json());
 
@@ -157,16 +147,18 @@ describe('Sanctions Credential Issuance', () => {
   });
 
   test('add service endpoint to existing DID document', async () => {
+    // :snippet-start: updateADidWithServiceEndpointJS
     issuerBearerDid.document.service.push({
       id: 'idv',
       type: 'IDV',
       serviceEndpoint: 'https://exampleIdvEndpoint.com/idv/siopv2/initiate',
     });
     
-    const updatedDocument = await DidDht.publish({ did: issuerBearerDid });
+    const updatedDidDocument = await DidDht.publish({ did: issuerBearerDid });
+    // :snippet-end:
 
-    expect(updatedDocument.didDocument).toHaveProperty('service');
-    expect(updatedDocument.didDocument.service.some(service => service.id === 'idv')).toBeTruthy();
+    expect(updatedDidDocument.didDocument).toHaveProperty('service');
+    expect(updatedDidDocument.didDocument.service.some(service => service.id === 'idv')).toBeTruthy();
   });
 
   test('.create() creates a credential with expected fields', async () => {

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/credentialIssuance.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/credentialIssuance.test.js
@@ -53,7 +53,7 @@ issuerBearerDid.document.service.push({
   serviceEndpoint: 'https://exampleIdvEndpoint.com/idv/siopv2/initiate',
 });
 
-await DidDht.publish({ did: issuerDid });
+await DidDht.publish({ did: issuerBearerDid });
 // :snippet-end:
 
 const app = express();
@@ -154,6 +154,19 @@ describe('Sanctions Credential Issuance', () => {
     expect(verificationResult).toHaveProperty('payload');
     expect(verificationResult.payload).toHaveProperty('iss');
     expect(verificationResult.payload).toHaveProperty('sub');
+  });
+
+  test('add service endpoint to existing DID document', async () => {
+    issuerBearerDid.document.service.push({
+      id: 'idv',
+      type: 'IDV',
+      serviceEndpoint: 'https://exampleIdvEndpoint.com/idv/siopv2/initiate',
+    });
+    
+    const updatedDocument = await DidDht.publish({ did: issuerBearerDid });
+    console.log(updatedDocument)
+
+    expect(updatedDocument.didDocument).toHaveProperty('service');
   });
 
   test('.create() creates a credential with expected fields', async () => {

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/credentialIssuance.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/credentialIssuance.test.js
@@ -166,6 +166,7 @@ describe('Sanctions Credential Issuance', () => {
     const updatedDocument = await DidDht.publish({ did: issuerBearerDid });
 
     expect(updatedDocument.didDocument).toHaveProperty('service');
+    expect(updatedDocument.didDocument.service.some(service => service.id === 'idv')).toBeTruthy();
   });
 
   test('.create() creates a credential with expected fields', async () => {

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/CredentialIssuanceTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/CredentialIssuanceTest.kt
@@ -61,20 +61,7 @@ private fun createADid() = runBlocking {
     val issuerBearerDid = DidDht.create(InMemoryKeyManager(), options)
     // :snippet-end:
 }
-private fun updateADid() = runBlocking {
-    val keyManager = InMemoryKeyManager()
-    val issuerBearerDid = DidDht.create(keyManager, CreateDidDhtOptions(publish = true))
-    // :snippet-start: updateADidWithAServiceEndpointKT
-    val serviceToAdd = Service.Builder()
-    .id("idv")
-    .type("IDV")
-    .serviceEndpoint(listOf("https://exampleIdvEndpoint.com/idv/siopv2/initiate"))
-    .build()
 
-    issuerBearerDid.document.service.orEmpty() + serviceToAdd
-    DidDht.publish(keyManager, issuerBearerDid.document)
-    // :snippet-end:
-}
 
 class CredentialIssuanceTest {
 


### PR DESCRIPTION
- Removing `updateADidWithAServiceEndpointKT` snippet from Credential Issuer Setup Guide until this [bug](https://github.com/TBD54566975/web5-kt/issues/310) is resolved. 
- Add test for JS snippet `updateADidWithAServiceEndpointJS`

### Direct Link To Preview
https://deploy-preview-1418--tbd-website-developer.netlify.app/docs/tbdex/issuer/vc-serverSetup?lang=Kotlin

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207237436620155