### PR TITLE
Add ReplyTo Usage for Kotlin

### DIFF
--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/ExchangesApiProvider.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/ExchangesApiProvider.kt
@@ -5,7 +5,7 @@ import tbdex.sdk.protocol.models.Message
 
 class ExchangesApiProvider: MockExchangesApiProvider() {
     // :snippet-start: pfiOverviewWriteKt
-    fun write(message: Message) {
+    fun write(message: Message, replyTo: String = "") {
         val data = mapOf(
             "exchangeid" to message.metadata.exchangeId,
             "messagekind" to message.metadata.kind,
@@ -14,6 +14,14 @@ class ExchangesApiProvider: MockExchangesApiProvider() {
             "message" to message.data
         )
         dataProvider.insert("exchange", data)
+
+        if (replyTo.isNotEmpty()) {
+            val callbackData = mapOf(
+                "exchangeId" to message.metadata.exchangeId,
+                "uri" to replyTo
+            )
+            dataProvider.insert("callbacks", replyTo)
+        }
     }
     // :snippet-end:
 }

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt
@@ -48,7 +48,7 @@ class PfiStructureTest {
     fun `PFI initializes routes`() {
         // :snippet-start: pfiOverviewServerRoutesKt
         tbDexServer.onCreateExchange { call, message, offering, replyTo ->
-            exchangesApiProvider.write(message)
+            exchangesApiProvider.write(message, replyTo ?: "")
             call.respond(HttpStatusCode.Accepted)
         }
 


### PR DESCRIPTION
This pull request primarily updates the `ExchangesApiProvider` and `PfiStructureTest` classes in the `site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi` directory. The changes enable the `write` method to handle a `replyTo` parameter, which is used to provide callback functionality. The `write` method now inserts callback data into the `dataProvider` if `replyTo` is not empty. Additionally, the `PFI initializes routes` test in `PfiStructureTest` has been updated to pass the `replyTo` parameter to the `write` method.

Changes to `ExchangesApiProvider`:

* [`site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/ExchangesApiProvider.kt`](diffhunk://#diff-5f3f9c2997b059196bf97bbfa028cdf17e25cc0a2ca2cfff98cacf54555af7a7L8-R8): The `write` method now accepts a `replyTo` parameter with a default value of an empty string.
* [`site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/ExchangesApiProvider.kt`](diffhunk://#diff-5f3f9c2997b059196bf97bbfa028cdf17e25cc0a2ca2cfff98cacf54555af7a7R17-R24): If `replyTo` is not empty, the `write` method creates a `callbackData` map and inserts it into `dataProvider`.

Changes to `PfiStructureTest`:

* [`site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiStructureTest.kt`](diffhunk://#diff-797a1c6f1a80cec7127063ef1381e4d2df345bdfb1c9d217b29ee139e11b2f5aL51-R51): The `PFI initializes routes` test now passes `replyTo` to the `write` method. If `replyTo` is null, an empty string is passed instead.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207237436620151