### PR TITLE
createFrom added to guide

### DIFF
--- a/site/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx
@@ -17,16 +17,16 @@ Various data types, such as text, JSON, images, streams or files, can be stored 
 
 ### Create a blob or image record
 
-<CodeSnippet functionName='uploadImage'/>
+<CodeSnippet snippetName='uploadImage'/>
 
 ### Create a file record
 
-<CodeSnippet functionName='uploadFile'/>
+<CodeSnippet snippetName='uploadFile'/>
 
 ### Create records with mixed data
 You can also store mixed data via JSON - including text, images, or files.
 
-<CodeSnippet functionName='createMixedRecord'/>
+<CodeSnippet snippetName='createMixedRecord'/>
 
 ## Create records from an existing record
 You can create a new version of a record while maintaining a link to the version of the original record.

--- a/site/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx
@@ -9,11 +9,11 @@ Various data types, such as text, JSON, images, streams or files, can be stored 
 
 ### Create a text record
 
-<CodeSnippet functionName='createTextRecord'/>
+<CodeSnippet snippetName='createTextRecord'/>
 
 ### Create a JSON record
 
-<CodeSnippet functionName='createJsonRecord'/>
+<CodeSnippet snippetName='createJsonRecord'/>
 
 ### Create a blob or image record
 
@@ -28,5 +28,9 @@ You can also store mixed data via JSON - including text, images, or files.
 
 <CodeSnippet functionName='createMixedRecord'/>
 
+## Create records from an existing record
+You can create a new version of a record while maintaining a link to the version of the original record.
+
+<CodeSnippet snippetName='createRecordFrom'/>
 
 For more information on writing records to DWNs, see our [API Guide](https://tbd54566975.github.io/web5-js/classes/_web5_api.DwnApi.html#records).

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
@@ -150,18 +150,9 @@ test('createRecordFrom creates a record from an existing record', async () => {
     },
   });
   // :snippet-start: createRecordFrom
-  // Get original record by id
-  let { record: existingRecord } = await web5.dwn.records.read({
-    message: {
-      filter: {
-        recordId: originalRecord.id,
-      },
-    },
-  });
-
   // Create a new version of the record based on the existing record
   const { record: newVersionRecord } = await web5.dwn.records.createFrom({
-    record: existingRecord,
+    record: originalRecord,
     data: 'I am a new version of the original record!',
     message: {
       dataFormat: 'application/json',

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
@@ -150,7 +150,7 @@ test('createRecordFrom creates a record from an existing record', async () => {
     },
   });
   // :snippet-start: createRecordFrom
-  // Create a new version of the record based on the existing record
+  // Create a new version of the record based on the original record
   const { record: newVersionRecord } = await web5.dwn.records.createFrom({
     record: originalRecord,
     data: 'I am a new version of the original record!',

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
@@ -155,7 +155,7 @@ test('createRecordFrom creates a record from an existing record', async () => {
     record: originalRecord,
     data: 'I am a new version of the original record!',
     message: {
-      dataFormat: 'application/json',
+      dataFormat: 'text/plain',
       published: true,
     },
   });

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
@@ -21,12 +21,34 @@ describe('write-to-dwn', () => {
   });
 
   test('createTextRecord creates a text record', async () => {
-    const record = await createTextRecord(web5);
+    // :snippet-start: createTextRecord
+    // Create a plain text record
+    const { record } = await web5.dwn.records.create({
+      data: {
+        content: "Hello Web5",
+        description: "Keep Building!"
+      },
+      message: {
+        dataFormat: 'application/json'
+      }
+    });
+    // :snippet-end:
     expect(record).toBeDefined();
   });
 
   test('createJsonRecord creates a JSON record', async () => {
-    const record = await createJsonRecord(web5);
+    // :snippet-start: createJsonRecord
+    // Create a JSON record
+    const { record } = await web5.dwn.records.create({
+      data: {
+        content: "Hello Web5",
+        description: "Keep Building!"
+      },
+      message: {
+        dataFormat: 'application/json'
+      }
+    });
+     // :snippet-end:
     expect(record).toBeDefined();
   });
 
@@ -61,4 +83,35 @@ describe('write-to-dwn', () => {
     const record = await createMixedRecord(username, messageText, imageFile);
     expect(record).toBeDefined();
   });
+});
+
+test('createRecordFrom creates a record from an existing record', async () => {
+  const { record } = await web5.dwn.records.create({
+    data: 'Hello, Web5!',
+    message: {
+      dataFormat: 'text/plain',
+    },
+  });
+  // :snippet-start: createRecordFrom
+  // Get existing record by id
+  let { record: existingRecord } = await web5.dwn.records.read({
+    message: {
+      filter: {
+        recordId: record.id,
+      },
+    },
+  });
+
+  // Create a new record from an existing record
+  const { record: newRecord } = await web5.dwn.records.createFrom({
+    record: existingRecord,
+    data: 'I am a new version of the original record!',
+    message: {
+      dataFormat: 'application/json',
+      published: true,
+    },
+  });
+  // :snippet-end:
+  const newRecordDataText = await newRecord.data.text();
+  expect(newRecordDataText).toBe('I am a new version of the original record!');
 });


### PR DESCRIPTION
This pull request primarily involves updates to the documentation and tests related to the creation of records in the `write-to-dwn` module. The changes include renaming the `functionName` attribute to `snippetName` in the `CodeSnippet` component, adding a new section to the documentation about creating records from an existing record, and updating the tests to reflect these changes.

Updates to the documentation:

* [`site/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx`](diffhunk://#diff-5752dfa162025e7e670ffd654532efc6e61f1632423d0a9bfd38a693fc7fc6dbL12-R16): Renamed the `functionName` attribute to `snippetName` in the `CodeSnippet` component for creating text, JSON, and mixed records.
* [`site/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx`](diffhunk://#diff-5752dfa162025e7e670ffd654532efc6e61f1632423d0a9bfd38a693fc7fc6dbR31-R34): Added a new section about creating records from an existing record.

Updates to the tests:

* [`site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js`](diffhunk://#diff-aa48069f8d206290c34cfea31e8b0996e62e800813045d9b0c5d07dc53898338L24-R51): Updated the tests for creating text and JSON records to reflect the change from `functionName` to `snippetName`.
* [`site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js`](diffhunk://#diff-aa48069f8d206290c34cfea31e8b0996e62e800813045d9b0c5d07dc53898338R87-R117): Added a new test for creating a record from an existing record.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206275229670918