### PR TITLE
Removing republishing dids warning

### DIFF
--- a/site/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
+++ b/site/docs/web5/build/decentralized-identifiers/how-to-create-did.mdx
@@ -57,10 +57,6 @@ The following DID methods are supported:
   ]}
 />
 
-:::danger Important: Weekly Republishing Required for `did:dht` DIDs
-**Temporarily** DIDs created using the `did:dht` method **must** be republished weekly to prevent them from becoming unresolvable. An automatic republishing feature will be integrated into the SDK in the coming weeks.
-:::
-
 ### did\:jwk
 
 <Shnip

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did.test.js
@@ -58,6 +58,7 @@ import { DidJwk } from '@web5/dids'
 
     // DID Document
     const didDocument = JSON.stringify(didDht.document);
+    
     // :snippet-end:
 
     expect(did).toMatch(/^did:dht:/);

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-identifiers/how-to-create-did.test.js
@@ -58,10 +58,6 @@ import { DidJwk } from '@web5/dids'
 
     // DID Document
     const didDocument = JSON.stringify(didDht.document);
-
-    // Republish DID 
-    const republishedDid = await DidDht.publish({did: didDht});
-
     // :snippet-end:
 
     expect(did).toMatch(/^did:dht:/);

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.kt
@@ -27,6 +27,7 @@ internal class HowToCreateDidTest {
 
     //DID Document
     val didDocument = portableDid.didDocument
+    
     // :snippet-end:
 
     assertNotNull(did, "DID should not be null")

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/web5/build/decentralizedidentifiers/HowToCreateDidTest.kt
@@ -27,11 +27,6 @@ internal class HowToCreateDidTest {
 
     //DID Document
     val didDocument = portableDid.didDocument
-
-    //Republish Did
-    DidDht.publish( didDht.keyManager, didDht.document )
-
-
     // :snippet-end:
 
     assertNotNull(did, "DID should not be null")


### PR DESCRIPTION
From chatting back and forth with Gabe and Frank, they advise that we remove this warning about DID DHT because this is currently not the case. At the moment, people don't need to republish DIDs weekly. However, they plan to implement a way to make storing and managing DIDs more sustainable for our company...so that old, unused DIDs aren't just sitting in our system.  Gabe is currently working on implementing new plan. Share the exact and correct guidance with us and we can update our docs to reflect his new guidance.

New plan was agreed on: 
```
person gets a did dht
on our side we're checking to see if the did is active for the last 7 days
if it becomes inactive..they have to republish..if it's not inactive and meets minimal requirements for use..they dont have to republish.
the activity/inactivity is what they refer to as proof of work
```

It sounds like they're still trying to determine what is "activity"

This pull request includes a change in the `how-to-create-did.mdx` file under the `site/docs/web5/build/decentralized-identifiers` directory. The change involves the removal of an important note about the weekly republishing requirement for `did:dht` DIDs. The note stated that DIDs created using the `did:dht` method must be republished weekly to prevent them from becoming unresolvable and that an automatic republishing feature would be integrated into the SDK in the coming weeks.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207249235942948