### PR TITLE
adding prune record docs for new release

### DIFF
--- a/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
@@ -21,3 +21,9 @@ The following snippets allow you to delete from a DWN:
 <CodeSnippet functionName='deleteRecordFromDid'/>
 
 The value for `from` is the target DID that you wish to delete the record from.
+
+## Delete parent record and all children
+
+To delete a parent record along with all its child records, set the prune option to true.
+
+<CodeSnippet snippetName='pruneRecords'/>

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js
@@ -20,4 +20,61 @@ describe('delete-from-dwn', () => {
     const result = await deleteFromLocalDWN(web5, record.id);
     expect(result.status.code).toBe(202);
   });
+
+  test('pruneRecords deletes parents record and its children', async () => {
+    const { status: protocolStatus, protocol } = await web5.dwn.protocols.configure({
+      message: {
+        definition: {
+          protocol: 'http://example.com/parent-child',
+          published: true,
+          types: {
+            post: {
+              schema: 'http://example.com/post',
+            },
+            comment: {
+              schema: 'http://example.com/comment'
+            }
+          },
+          structure: {
+            post: {
+              comment: {}
+            }
+          }
+        }
+      }
+    });
+
+    const { record: parentRecord } = await web5.dwn.records.create({
+      data: 'Hello, world!',
+      message: {
+        protocol: protocol.definition.protocol,
+        protocolPath: 'post',
+        schema: 'http://example.com/post',
+        dataFormat: 'text/plain'
+      }
+    });
+
+    const { record: childRecord } = await web5.dwn.records.create({
+      data: 'Hello, world!',
+      message: {
+        protocol: protocol.definition.protocol,
+        protocolPath: 'post/comment',
+        schema: 'http://example.com/comment',
+        dataFormat: 'text/plain',
+        parentContextId: parentRecord.contextId
+      }
+    });
+
+    // :snippet-start: pruneRecords
+    const { status: deleteStatus } = await web5.dwn.records.delete({
+      message: {
+        recordId: parentRecord.id,
+        //highlight-next-line
+        prune: true
+      }
+    });
+    // :snippet-end:
+    expect(deleteStatus.code).toBe(202);
+
+  });
 });


### PR DESCRIPTION
---
**NOTE**

**One test failing. Liran and I looking into it. Please review for my changes.**

---


This pull request primarily focuses on adding a new feature to the decentralized web nodes (DWN) that allows users to delete a parent record and all its child records. This feature is implemented in the `delete-from-dwn` module and is tested in the `delete-from-dwn.test.js` file.

Feature addition:

* [`site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx`](diffhunk://#diff-edc31d12629a88be176c622555225cb7e45abbb4725548acca61e85b842204ddR24-R29): Added a section explaining how to delete a parent record along with all its child records by setting the prune option to true.

Testing:

* [`site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js`](diffhunk://#diff-2a1af6f11d5bdb294450ff4d40b3c40b9ffea3c56d1b45d328dc0923fa4b88beR23-R79): Added a test case to verify that the `pruneRecords` function deletes both the parent record and its children. The test case includes setting up a protocol with a parent-child structure, creating a parent record and a child record, and then deleting the parent record with the prune option set to true.