### PR TITLE
Adding close.data.success to Wallet guide

### DIFF
--- a/site/docs/tbdex/wallet/place-order.mdx
+++ b/site/docs/tbdex/wallet/place-order.mdx
@@ -89,7 +89,8 @@ Once a `Close` message is written, the exchange is ended and no additional messa
 }
 ```
 
-When the PFI closes the Order, it's important to check the `reason` on the Close message and report that to your customer, as it could be because the transaction was completed successfully or it could be that the Order has failed.
+When the PFI closes the Order, it's important to check the `success` indicator to determine if the transaction was completed successfully.
+In the event that it was not, there is a `reason` on the Close message that should provide more detail. 
 
 <Shnip
   snippets={[

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/wallet/placeOrder.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/wallet/placeOrder.test.js
@@ -126,9 +126,9 @@ describe('Wallet: Place Order', () => {
   test('listen for Order Status updates', async () => {
     // :snippet-start: listenForOrderStatusJS
     let orderStatusUpdate;
-    let closeMessage;
+    let close;
 
-    while (!closeMessage) {
+    while (!close) {
       const exchange = await TbdexHttpClient.getExchange({
         pfiDid: order.metadata.to,
         did: customerDid,
@@ -142,7 +142,7 @@ describe('Wallet: Place Order', () => {
         }
         else if (message instanceof Close){
           // final message of exchange has been written
-          closeMessage = message;
+          close = message;
           break;
         }
       }
@@ -151,9 +151,10 @@ describe('Wallet: Place Order', () => {
     expect.soft(orderStatusUpdate).toBe(orderStatusMsg);
 
     // :snippet-start: getCloseReasonJS
-    const reasonForClose = closeMessage.data.reason;
+    const isSuccessful = close.data.success;
+    const reasonForClose = close.data.reason;
     // :snippet-end:
     expect(reasonForClose).toBe(closeReason);
-    expect(closeMessage.data.success).toBe(true);
+    expect(isSuccessful).toBe(true);
   });
 });

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/utils/TestData.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/utils/TestData.kt
@@ -161,7 +161,7 @@ object TestData {
         to = ALICE_DID.uri,
         from = PFI_DID.uri,
         exchangeId = TypeId.generate(MessageKind.rfq.name).toString(),
-        closeData = CloseData(closeData)
+        closeData = CloseData(closeData, true)
     )
 
     fun getOrder(

--- a/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/MockData.swift
+++ b/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/MockData.swift
@@ -167,7 +167,8 @@ public struct MockData {
             to: to,
             exchangeID: exchangeId,
             data: .init(
-                reason: reason
+                reason: reason,
+                success: true
             ),
             protocol: "1.0"
         )

--- a/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/tbdex/wallet/PlaceOrderTests.swift
+++ b/site/testsuites/testsuite-swift/Tests/DevSiteTestSuiteTests/tbdex/wallet/PlaceOrderTests.swift
@@ -56,9 +56,9 @@ final class PlaceOrderTests: XCTestCase {
 
         // :snippet-start: listenForOrderStatusSwift
         var orderStatusUpdate: String?
-        var closeMessage: Close?
+        var close: Close?
 
-        while closeMessage == nil {
+        while close == nil {
             let exchange = try await tbDEXHttpClient.getExchange(
                 pfiDIDURI: quote!.metadata.from,
                 requesterDID: customerDid!,
@@ -70,9 +70,9 @@ final class PlaceOrderTests: XCTestCase {
                     // a status update to display to your customer
                     orderStatusUpdate = orderStatus.data.orderStatus
                 }
-                else if case .close(let close) = message {
+                else if case .close(let closeMessage) = message {
                     // final message of exchange has been written
-                    closeMessage = close
+                    close = closeMessage
                     break
                 }
             }
@@ -80,9 +80,11 @@ final class PlaceOrderTests: XCTestCase {
         // :snippet-end:
         
         // :snippet-start: getCloseReasonSwift
-        let reasonForClose = closeMessage!.data.reason
+        let isSuccessful = close!.data.success!
+        let reasonForClose = close!.data.reason
         // :snippet-end:
 
+        XCTAssertTrue(isSuccessful)
         XCTAssertEqual(reasonForClose, closeReason)
 
         //removing warning from console


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 📝 Documentation Update

## Description

The Wallet guide on Placing an Order did not show how to determine if the transaction was successful. This PR adds that info.


## Added code snippets?
- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed

## Added tests?

- [X] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207651243616779