### PR TITLE
removing import statements

### DIFF
--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/pfiOnboarding.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/pfi/pfiOnboarding.test.js
@@ -1,7 +1,7 @@
 // :snippet-start: pfiOnboardingImportsJs
 import { DidDht } from '@web5/dids';
-import { LocalKeyManager } from '@web5/crypto'; // optional
 // :snippet-end:
+import { LocalKeyManager } from '@web5/crypto';
 import { test, expect, describe } from 'vitest';
 
 describe('PFI: Onboarding', () => {

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiOnboardingTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/pfi/PfiOnboardingTest.kt
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.Assertions.*
 // :snippet-start: pfiOnboardingImportsKt
 import web5.sdk.dids.methods.dht.CreateDidDhtOptions
 import web5.sdk.dids.methods.dht.DidDht
-import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.didcore.Service
 // :snippet-end:
+import web5.sdk.crypto.InMemoryKeyManager
 
 /**
  * Tests for PFI Onboarding guide


### PR DESCRIPTION
PFIs shouldnt use InMemoryKeyManager in production. Don't want to show this bad habit in examples