### PR TITLE
add protocol tags to docs

### DIFF
--- a/site/docs/web5/build/decentralized-web-nodes/query-from-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/query-from-dwn.mdx
@@ -49,6 +49,7 @@ Here are the properties you can use to filter your record query, along with expl
 | **`parentId`**      | `recordId` of the parent record in a protocol        | "iadsfdreianzpmasdffcgam5mys722vnd..." |
 | **`dataFormat`**    | The IANA string for the data format to filter        | "application/json" |
 | **`dateCreated`**   | Date the record was created                          | "2023-04-30T22:49:37.713976Z" |
+| **`tags`**          | Key-value pairs for categorizing records             | `{"genre": "Action", "year": "2024"}`|
 
 ### Filter by parentId
 This snippet queries the DWN for records that have a parent record with a specific record ID:

--- a/site/docs/web5/build/decentralized-web-nodes/query-from-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/query-from-dwn.mdx
@@ -49,7 +49,7 @@ Here are the properties you can use to filter your record query, along with expl
 | **`parentId`**      | `recordId` of the parent record in a protocol        | "iadsfdreianzpmasdffcgam5mys722vnd..." |
 | **`dataFormat`**    | The IANA string for the data format to filter        | "application/json" |
 | **`dateCreated`**   | Date the record was created                          | "2023-04-30T22:49:37.713976Z" |
-| **`tags`**          | Key-value pairs for categorizing records             | `{"genre": "Action", "year": "2024"}`|
+| **`tags`**          | User-defined key-value pairs for categorizing records| `{"genre": "Action", "year": "2024"}`|
 
 ### Filter by parentId
 This snippet queries the DWN for records that have a parent record with a specific record ID:

--- a/site/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx
@@ -28,9 +28,13 @@ You can also store mixed data via JSON - including text, images, or files.
 
 <CodeSnippet snippetName='createMixedRecord'/>
 
-## Create records from an existing record
+### Create records from an existing record
 You can create a new version of a record while maintaining a link to the version of the original record.
 
 <CodeSnippet snippetName='createRecordFrom'/>
+
+### Create records with tags
+You can assign tags to records to enable filtering by specific keywords.
+<CodeSnippet snippetName='createRecordWithTags'/>
 
 For more information on writing records to DWNs, see our [API Guide](https://tbd54566975.github.io/web5-js/classes/_web5_api.DwnApi.html#records).

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
@@ -169,19 +169,19 @@ test('createRecordWithTags creates a record with tags', async() => {
   // :snippet-start: createRecordWithTags
   // Creates a record with tags
   const { record } = await web5.dwn.records.create({
-    data: "iPhone 13",
+    data: "Chocolate Chip Cookies",
     message: {
       dataFormat: 'application/json',
       tags    : {
-        manufacturer: 'Apple',
-        releaseYear: '2021',
+        dishType: 'Dessert',
+        dietaryRestriction: 'Contains Gluten'
       }
     }
   });
  // :snippet-end:
   expect(record.tags).to.exist;
   expect(record.tags).to.deep.equal({
-    manufacturer: 'Apple',
-    releaseYear: '2021',
+    dishType: 'Dessert',
+    dietaryRestriction: 'Contains Gluten'
   });
 })

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
@@ -163,3 +163,24 @@ test('createRecordFrom creates a record from an existing record', async () => {
   const newRecordDataText = await newVersionRecord.data.text();
   expect(newRecordDataText).toBe('I am a new version of the original record!');
 });
+
+test('createRecordWithTags creates a record with tags', async() => {
+   
+  // :snippet-start: createRecordWithTags
+  const { record } = await web5.dwn.records.create({
+    data: "iPhone 13",
+    message: {
+      dataFormat: 'application/json',
+      tags    : {
+        manufacturer: 'Apple',
+        year: '2021',
+      }
+    }
+  });
+ // :snippet-end:
+  expect(record.tags).to.exist;
+  expect(record.tags).to.deep.equal({
+    manufacturer: 'Apple',
+    year: '2021',
+  });
+})

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
@@ -174,7 +174,7 @@ test('createRecordWithTags creates a record with tags', async() => {
       dataFormat: 'application/json',
       tags    : {
         manufacturer: 'Apple',
-        year: '2021',
+        releaseYear: '2021',
       }
     }
   });

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
@@ -167,6 +167,7 @@ test('createRecordFrom creates a record from an existing record', async () => {
 test('createRecordWithTags creates a record with tags', async() => {
    
   // :snippet-start: createRecordWithTags
+  // Creates a record with tags
   const { record } = await web5.dwn.records.create({
     data: "iPhone 13",
     message: {

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js
@@ -182,6 +182,6 @@ test('createRecordWithTags creates a record with tags', async() => {
   expect(record.tags).to.exist;
   expect(record.tags).to.deep.equal({
     manufacturer: 'Apple',
-    year: '2021',
+    releaseYear: '2021',
   });
 })


### PR DESCRIPTION
The most significant changes include the addition of a new filter property for record queries, modification of the documentation to explain the new tagging feature, and the inclusion of a new test case to verify the tagging functionality.

Enhancements to record query:

* [`site/docs/web5/build/decentralized-web-nodes/query-from-dwn.mdx`](diffhunk://#diff-d1a221f6540e62798174c2c52168bd3af7409436e609d554053d0c4c5584fd86R52): A new `tags` property was added to the list of filter properties for record queries. This allows for records to be categorized using key-value pairs.

Documentation updates:

* [`site/docs/web5/build/decentralized-web-nodes/write-to-dwn.mdx`](diffhunk://#diff-5752dfa162025e7e670ffd654532efc6e61f1632423d0a9bfd38a693fc7fc6dbL31-R39): The section "Create records from an existing record" was demoted to a sub-section, and a new sub-section titled "Create records with tags" was added. This new section explains how to assign tags to records, enabling filtering by specific keywords.

New test case:

* [`site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/write-to-dwn.test.js`](diffhunk://#diff-aa48069f8d206290c34cfea31e8b0996e62e800813045d9b0c5d07dc53898338R166-R186): A new test case was added to verify the creation of records with tags. The test ensures that the `tags` property exists in the record and that it contains the correct key-value pairs.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207758653193383