### PR TITLE
Delete Records API has been updated to record.delete()

### DIFF
--- a/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
@@ -13,7 +13,7 @@ The following snippets allow you to delete from a DWN:
 
 ### Delete record from the user's local DWN
 
-<CodeSnippet functionName='deleteFromLocalDWN'/>
+<CodeSnippet snippetName='deleteRecordFromLocalDwn'/>
 
 
 ### Delete record from a remote DWN

--- a/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
@@ -18,7 +18,7 @@ The following snippets allow you to delete from a DWN:
 
 ### Delete record from a remote DWN
 
-<CodeSnippet functionName='deleteRecordFromDid'/>
+<CodeSnippet snippetName='deleteRecordFromRemoteDwn'/>
 
 The value for `from` is the target DID that you wish to delete the record from.
 

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js
@@ -1,6 +1,4 @@
 import { test, beforeAll, expect, describe } from 'vitest';
-
-import { deleteFromLocalDWN } from '../../../../../../code-snippets/web5/build/decentralized-web-nodes/delete-from-dwn';
 import { createLocalRecord, sendLocalRecordToTarget } from '../../../../../../code-snippets/web5/build/decentralized-web-nodes/send';
 import { setUpWeb5 } from '../../../setup-web5';
 

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js
@@ -1,7 +1,7 @@
 import { test, beforeAll, expect, describe } from 'vitest';
 
 import { deleteFromLocalDWN } from '../../../../../../code-snippets/web5/build/decentralized-web-nodes/delete-from-dwn';
-import { createLocalRecord } from '../../../../../../code-snippets/web5/build/decentralized-web-nodes/send';
+import { createLocalRecord, sendLocalRecordToTarget } from '../../../../../../code-snippets/web5/build/decentralized-web-nodes/send';
 import { setUpWeb5 } from '../../../setup-web5';
 
 let web5;
@@ -15,7 +15,7 @@ describe('delete-from-dwn', () => {
     did = globalThis.did;
   });
 
-  test('deleteFromLocalDWN deletes a record', async () => {
+  test('deleteRecordFromLocalDwn deletes a record', async () => {
     const record = await createLocalRecord(web5);
     // :snippet-start: deleteRecordFromLocalDwn
     const { status: deleteStatus } = await record.delete();
@@ -29,6 +29,18 @@ describe('delete-from-dwn', () => {
     });
     expect(deleteStatus.code).toBe(202);
     expect(readResult.status.code).toBe(404);
+  });
+
+  test('deleteRecordFromRemoteDwn deletes a remote record', async () => {
+    const record = await sendLocalRecordToTarget(web5, did);
+    // :snippet-start: deleteRecordFromRemoteDwn
+    const { status: deleteStatus } = await record.delete();
+    // send the delete request to the remote DWN
+    const { status: deleteSendStatus } = await record.send(did);
+    // :snippet-end:
+    expect(record.deleted).toBe(true);
+    expect(deleteStatus.code).toBe(202);
+    expect(deleteSendStatus.code).toEqual(202);
   });
 
   test('pruneRecords deletes parents record and its children', async () => {
@@ -76,13 +88,7 @@ describe('delete-from-dwn', () => {
     });
 
     // :snippet-start: pruneRecords
-    const { status: deleteStatus } = await web5.dwn.records.delete({
-      message: {
-        recordId: parentRecord.id,
-        //highlight-next-line
-        prune: true
-      }
-    });
+    const { status: deleteStatus } = await parentRecord.delete({ prune: true });
     // :snippet-end:
 
     const { records: childrenRecordsAfterDelete } = await web5.dwn.records.query({

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js
@@ -17,8 +17,18 @@ describe('delete-from-dwn', () => {
 
   test('deleteFromLocalDWN deletes a record', async () => {
     const record = await createLocalRecord(web5);
-    const result = await deleteFromLocalDWN(web5, record.id);
-    expect(result.status.code).toBe(202);
+    // :snippet-start: deleteRecordFromLocalDwn
+    const { status: deleteStatus } = await record.delete();
+    // :snippet-end:
+    const readResult = await web5.dwn.records.read({
+      message: {
+        filter: {
+          recordId: record.id
+        }
+      }
+    });
+    expect(deleteStatus.code).toBe(202);
+    expect(readResult.status.code).toBe(404);
   });
 
   test('pruneRecords deletes parents record and its children', async () => {

--- a/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/upgrade-to-pwa.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/upgrade-to-pwa.test.js
@@ -1,0 +1,51 @@
+import { beforeAll, beforeEach, afterEach, describe, test, expect, vi } from 'vitest';
+import { setUpWeb5 } from '../../../setup-web5';
+
+describe('Testing upgrade to PWA', () => {
+  let web5, did;
+  const recordId = "bafyreifsfh74ghrkmok7rw5ci6ayhz2bdoeaen4udygmq52twi5lu2jsju";  
+  let originalFetch;
+
+  beforeAll(async () => {
+    await setUpWeb5();
+    web5 = globalThis.web5;
+    did = globalThis.did;
+  });
+
+  beforeEach(() => {
+    originalFetch = global.fetch; // Save the original fetch function
+    // Mock @web5/api
+    vi.mock('@web5/api', () => ({
+      Web5: {
+        connect: vi.fn(() => Promise.resolve({ web5, did }))
+      }
+    }));
+
+    // Mock fetch globally in your test environment
+    global.fetch = vi.fn((url) => {
+      if (url === `https://dweb/${did}/read/records/${recordId}`) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ data: "Hello, World" })
+        });
+      }
+      return Promise.reject(new Error('URL not found'));
+    });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks(); // Reset mocks to their original state
+    global.fetch = originalFetch; // Restore the original fetch function
+  });
+
+  test('drl fetches a read record', async () => {
+    const dwebUrl = `https://dweb/${did}/read/records/${recordId}`;
+    const response = await fetch(dwebUrl);
+    const data = await response.json();
+
+    expect(response.ok).toBeTruthy();
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ data: "Hello, World" });
+  });
+});


### PR DESCRIPTION
This pull request mainly focuses on improving the codebase for the decentralized web nodes (DWN) and adding a new test suite for the upgrade to PWA. The most important changes include modifying the code snippet name in the documentation, updating the test for deleting a record from the local DWN, and adding a new test suite for upgrading to PWA.

Changes in the documentation:

* [`site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx`](diffhunk://#diff-edc31d12629a88be176c622555225cb7e45abbb4725548acca61e85b842204ddL16-R16): The code snippet name was changed from `deleteFromLocalDWN` to `deleteRecordFromLocalDwn` to better represent its functionality.

Changes in the test suites:

* [`site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js`](diffhunk://#diff-2a1af6f11d5bdb294450ff4d40b3c40b9ffea3c56d1b45d328dc0923fa4b88beL20-R31): The test for deleting a record from the local DWN was updated. Instead of calling a function `deleteFromLocalDWN`, the `delete` method is now directly called on the record object. Additionally, a check was added to ensure that the record is not found after deletion.
* [`site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/upgrade-to-pwa.test.js`](diffhunk://#diff-334931cf250cfcc175ebe864f8757fec2b5841d56893012b2e86a5fbcc0c164cR1-R51): A new test suite was added for testing the upgrade to PWA. This includes setting up the web5 environment, mocking the web5 API and the global fetch function, and testing the fetch of a read record.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207837410653545