### PR TITLE
records delete API has changed

### DIFF
--- a/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
@@ -13,12 +13,12 @@ The following snippets allow you to delete from a DWN:
 
 ### Delete record from the user's local DWN
 
-<CodeSnippet functionName='deleteFromLocalDWN'/>
+<CodeSnippet snippetName='deleteRecordFromLocalDwn'/>
 
 
 ### Delete record from a remote DWN
 
-<CodeSnippet functionName='deleteRecordFromDid'/>
+<CodeSnippet snippetName='deleteRecordFromRemoteDwn'/>
 
 The value for `from` is the target DID that you wish to delete the record from.
 


### PR DESCRIPTION
The records.delete() API has been updated, so I updated the documentation to reflect that. 

Link to deploy preview: 
https://deploy-preview-1480--tbd-website-developer.netlify.app/docs/web5/build/decentralized-web-nodes/delete-from-dwn

Changes in documentation:

* [`site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx`](diffhunk://#diff-edc31d12629a88be176c622555225cb7e45abbb4725548acca61e85b842204ddL16-R21): Renamed the code snippets for deleting records from local and remote DWNs. The `<CodeSnippet functionName='deleteFromLocalDWN'/>` and `<CodeSnippet functionName='deleteRecordFromDid'/>` have been replaced with `<CodeSnippet snippetName='deleteRecordFromLocalDwn'/>` and `<CodeSnippet snippetName='deleteRecordFromRemoteDwn'/>` respectively.

Changes in test suite:

* [`site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js`](diffhunk://#diff-2a1af6f11d5bdb294450ff4d40b3c40b9ffea3c56d1b45d328dc0923fa4b88beL2-R2): Updated the imports and renamed the test case for deleting a record from a local DWN. The function `deleteFromLocalDWN` has been replaced with method calls on the record object. [[1]](diffhunk://#diff-2a1af6f11d5bdb294450ff4d40b3c40b9ffea3c56d1b45d328dc0923fa4b88beL2-R2) [[2]](diffhunk://#diff-2a1af6f11d5bdb294450ff4d40b3c40b9ffea3c56d1b45d328dc0923fa4b88beL18-R41)
* [`site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js`](diffhunk://#diff-2a1af6f11d5bdb294450ff4d40b3c40b9ffea3c56d1b45d328dc0923fa4b88beL18-R41): Added a new test case for deleting a record from a remote DWN. The function `deleteRecordFromDid` has been replaced with method calls on the record object.
* [`site/testsuites/testsuite-javascript/__tests__/web5/build/decentralized-web-nodes/delete-from-dwn.test.js`](diffhunk://#diff-2a1af6f11d5bdb294450ff4d40b3c40b9ffea3c56d1b45d328dc0923fa4b88beL69-R89): Updated the test case for pruning records. The function call `web5.dwn.records.delete` has been replaced with a method call on the parent record object.