### PR TITLE
Removes line about from target DID

### DIFF
--- a/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
+++ b/site/docs/web5/build/decentralized-web-nodes/delete-from-dwn.mdx
@@ -20,8 +20,6 @@ The following snippets allow you to delete from a DWN:
 
 <CodeSnippet snippetName='deleteRecordFromRemoteDwn'/>
 
-The value for `from` is the target DID that you wish to delete the record from.
-
 ### Delete parent record and all children
 
 To delete a parent record along with all its child records, set the prune option to true.


### PR DESCRIPTION
Preview: https://deploy-preview-1481--tbd-website-developer.netlify.app/docs/web5/build/decentralized-web-nodes/delete-from-dwn

After merging, I realized this line was still in the doc, but it's an irrelevant note now that delete records API has changed. 
`The value for from is the target DID that you wish to delete the record from.`

This pull request includes a minor change to the `delete-from-dwn.mdx` file. The change removes a line of text that previously explained the purpose of the `from` value in a code snippet.