### PR TITLE
skipping failed wallet quickstart

### DIFF
--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/wallet/walletQuickstart.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/wallet/walletQuickstart.test.js
@@ -10,7 +10,7 @@ let pfiDid = 'did:dht:rj9xmgqcqs1rysongf833wo5g1dtabbhnimcorczcyurke4fmizo';
 
 describe('Wallet: Quickstart', () => {
 
-    it('Testing Quickstart Workflow', async () => {
+    it.skip('Testing Quickstart Workflow', async () => {
 
         // :snippet-start: walletQuickstartDidCreate
         var customerDid = await DidJwk.create({


### PR DESCRIPTION
Wallet Quickstart is failing. @chris-tbd indicated it's an issue with did:dht. Disabling the test until he can investigate so that it's not failing all other PRs