### PR TITLE
switch web5 quickstart to use shnip

### DIFF
--- a/site/docs/web5/quickstart.mdx
+++ b/site/docs/web5/quickstart.mdx
@@ -11,6 +11,8 @@ import PackageJson from '@site/src/components/PackageJson';
 import CodeSnippet from '@site/src/components/CodeSnippet';
 import QuickstartCodeRunner from '@site/src/components/QuickstartCodeRunner';
 
+<LanguageSwitcher languages="JavaScript" />
+
 <QuickstartExecutionProvider>
 # Web5 in 5️⃣ minutes
 
@@ -157,7 +159,11 @@ This DID URI is part of a broader JSON object, known as a [Bearer DID](http://de
 
 To access your Bearer DID, add the following lines of code to your `index.js`:
 
-<CodeSnippet snippetName="getBearerDid" />
+<Shnip
+  snippets={[
+    { snippetName: 'getBearerDid', language: 'JavaScript'},
+    ]}
+/>
 
 <details>
     <summary>Test your code</summary>
@@ -189,7 +195,12 @@ In this step, you'll enable your users to create a self-signed VC -- allowing th
 
 In your `index.js`, create your Verifiable Credential:
 
-<CodeSnippet snippetName="createQuickstartVc" />
+<Shnip
+  snippets={[
+    { snippetName: 'createQuickstartVc', language: 'JavaScript'},
+    ]}
+/>
+
 
 <details>
     <summary>Test your code</summary>
@@ -222,7 +233,12 @@ Now, your users can sign the VC with their Bearer DID to ensure its authenticity
 
 To allow users to sign a VC, add this line to your `index.js`:
 
-<CodeSnippet snippetName="signQuickstartVc" />
+<Shnip
+  snippets={[
+    { snippetName: 'signQuickstartVc', language: 'JavaScript'},
+    ]}
+/>
+
 
 When an issuer signs a VC, it attests that they are truly the one who issued it. 
 This cryptographic process also converts the VC into a [JSON Web Token (JWT)](https://jwt.io/), making the credential tamper-evident and verifiable by others.
@@ -274,7 +290,11 @@ A user can host their DWN in multiple locations. The Web5 SDK is both browser an
 
 To store a VC in a DWN, add the following lines of code to your `index.js`:
 
-<CodeSnippet snippetName="writeQuickstartVcToDwn" />
+<Shnip
+  snippets={[
+    { snippetName: 'writeQuickstartVcToDwn', language: 'JavaScript'},
+    ]}
+/>
 
 <details>
     <summary>Test your code</summary>
@@ -308,7 +328,13 @@ If the user has given your app read permissions to their DWN, you can read their
 
 To read the JWT-encoded VC stored in your DWN, add the following to your `index.js`:
 
-<CodeSnippet snippetName="readQuickstartVc" />
+<Shnip
+  snippets={[
+    { snippetName: 'readQuickstartVc', language: 'JavaScript'},
+    ]}
+/>
+
+
 
 :::note
 Since the record is [public](https://developer.tbd.website/docs/web5/build/decentralized-web-nodes/publishing-records) 
@@ -350,7 +376,12 @@ This allows you to inspect the contents of the VC in a readable format.
 
 Add the following line to your index.js to parse the JWT-encoded VC:
 
-<CodeSnippet snippetName="parseQuickstartVc"/>
+<Shnip
+  snippets={[
+    { snippetName: 'parseQuickstartVc', language: 'JavaScript'},
+    ]}
+/>
+
 
 <details>
     <summary>Test your code</summary>


### PR DESCRIPTION
This pull request to `site/docs/web5/quickstart.mdx` includes changes to improve the documentation and code snippets. The most important changes include adding a `LanguageSwitcher` component, and replacing `CodeSnippet` components with `Shnip` components, which allow for language-specific snippets.

Addition of new components:

* [`site/docs/web5/quickstart.mdx`](diffhunk://#diff-77608684b254549f6eff3a9ed1b3bd28f7d9d56b356414de34ceea951ab6cc18R14-R15): Added a `LanguageSwitcher` component to allow users to switch between different programming languages.

Replacement of `CodeSnippet` with `Shnip`:

* [`site/docs/web5/quickstart.mdx`](diffhunk://#diff-77608684b254549f6eff3a9ed1b3bd28f7d9d56b356414de34ceea951ab6cc18L160-R166): Replaced `CodeSnippet` components with `Shnip` components in several code snippets, allowing for language-specific snippets. These changes were made in the sections about accessing Bearer DID, creating Verifiable Credentials, signing the VC, storing the VC in a DWN, reading the JWT-encoded VC stored in the DWN, and parsing the JWT-encoded VC. [[1]](diffhunk://#diff-77608684b254549f6eff3a9ed1b3bd28f7d9d56b356414de34ceea951ab6cc18L160-R166) [[2]](diffhunk://#diff-77608684b254549f6eff3a9ed1b3bd28f7d9d56b356414de34ceea951ab6cc18L192-R203) [[3]](diffhunk://#diff-77608684b254549f6eff3a9ed1b3bd28f7d9d56b356414de34ceea951ab6cc18L225-R241) [[4]](diffhunk://#diff-77608684b254549f6eff3a9ed1b3bd28f7d9d56b356414de34ceea951ab6cc18L277-R297) [[5]](diffhunk://#diff-77608684b254549f6eff3a9ed1b3bd28f7d9d56b356414de34ceea951ab6cc18L311-R337) [[6]](diffhunk://#diff-77608684b254549f6eff3a9ed1b3bd28f7d9d56b356414de34ceea951ab6cc18L353-R384)