### PR TITLE
misspelled introducing on blog post

### DIFF
--- a/site/blog/2024-07-31-simplying-cross-platform-payments-daps.md
+++ b/site/blog/2024-07-31-simplying-cross-platform-payments-daps.md
@@ -41,7 +41,7 @@ This situation creates an uncomfortable, unspoken battle when you need to pay a 
 
 Instead, P2P payment apps can use DAPs&mdash;agnostic unique identifiers stored in a registry&mdash;to identify and route payments to the correct destination across different platforms. This allows you and the recipient to financially "dap each other up" regardless of which apps you prefer.
 
-## Introducting Decentralized Agnostic Paytags (DAPs)
+## Introducing Decentralized Agnostic Paytags (DAPs)
 
 A DAP is a user-friendly handle for payments, structured as `@local-handle/domain`. 
 


### PR DESCRIPTION
This pull request includes a small change to the `site/blog/2024-07-31-simplying-cross-platform-payments-daps.md` file. The change corrects a typographical error in a section heading.

* [`site/blog/2024-07-31-simplying-cross-platform-payments-daps.md`](diffhunk://#diff-0a94831d8aa1ad9ce0c07ba00a80664a42aa83ae3bc0a68fa2d3c7c41389652cL44-R44): Corrected "Introducting" to "Introducing" in the section heading. 🤦🏿‍♀️