### PR TITLE
KBC Guide

### DIFF
--- a/site/docs/tbdex/issuer/kbc/_category_.json
+++ b/site/docs/tbdex/issuer/kbc/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Known Business Credential",
+    "position": 5
+  }
+  

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -11,7 +11,6 @@ hide_title: true
 Known Business Credentials (KBC) are [Verifiable Credentials](/docs/web5/verifiable-credentials/what-are-vcs) designed to streamline the Know Your Business (KYB) process for tbDEX protocol users. 
 By issuing this credential, the PFI attests to the business’s legitimacy and compliance with regulations, allowing the PFI to engage in financial activities with the Wallet application without requiring individual KYC for each customer.
 
-This guide is intended for PFIs that are using tbDEX to transact with other known businesses, without directly onboarding those businesses’ customers."
 
 :::danger Important
 This guide is intended for educational purposes only and does not constitute legal advice. Compliance programs may have varying requirements. Consult your legal and/or compliance advisors to ensure that the KBC is consistent with your legal and compliance obligations.

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -16,10 +16,9 @@ By issuing this credential, the PFI attests to the business’s legitimacy and c
 This guide is intended for educational purposes only and does not constitute legal advice. Compliance programs may have varying requirements. Consult your legal and/or compliance advisors to ensure that the KBC is consistent with your legal and compliance obligations.
 :::
 
-
-In this guide, we'll cover how a PFI (like Bob's company) can issue a KBC to a wallet app (like Alice's) on tbDEX:
-- Designing and issuing a KBC
-- Specifying a KBC as a required claim in an [Offering](/docs/tbdex/pfi/creating-offerings)
+In this guide, we'll cover how to:
+- Design and issue a KBC
+- Specify a KBC as a required claim in an [Offering](https://developer.tbd.website/docs/tbdex/pfi/creating-offerings)
 
 ## Environment Setup
 

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -17,7 +17,7 @@ This guide is intended for educational purposes only and does not constitute leg
 :::
 
 ## TL;DR
-For example, Alice's company runs a wallet app for international money transfers, handling various currencies. Currently, each large currency exchange requires a costly and time-consuming KYC check for every customer. To streamline this process and reduce expenses, Alice's company decides to obtain a KYB credential from Bob's Global Exchange, a Participating Financial Institution (PFI) on the tbDEX network.
+For example, Alice's company runs a wallet app for international money transfers, handling various currencies. Each large currency exchange requires a costly and time-consuming KYC check for every customer.To streamline this process and reduce expenses, Alice's company obtains a KYB credential from Bob's Global Exchange, a [Participating Financial Institution (PFI)](/docs/tbdex/pfi/overview) on the tbDEX network.
 
 In this guide, we'll cover how a PFI (like Bob's company) can issue a KBC to a wallet app (like Alice's) on tbDEX:
 - Designing and issuing a KBC

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -16,7 +16,6 @@ By issuing this credential, the PFI attests to the business’s legitimacy and c
 This guide is intended for educational purposes only and does not constitute legal advice. Compliance programs may have varying requirements. Consult your legal and/or compliance advisors to ensure that the KBC is consistent with your legal and compliance obligations.
 :::
 
-## TL;DR
 
 In this guide, we'll cover how a PFI (like Bob's company) can issue a KBC to a wallet app (like Alice's) on tbDEX:
 - Designing and issuing a KBC

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -17,7 +17,7 @@ This guide is intended for educational purposes only and does not constitute leg
 :::
 
 ## TL;DR
-For example, Alice's company runs a wallet app for international money transfers, handling various currencies. Each large currency exchange requires a costly and time-consuming KYC check for every customer.To streamline this process and reduce expenses, Alice's company obtains a KYB credential from Bob's Global Exchange, a [Participating Financial Institution (PFI)](/docs/tbdex/pfi/overview) on the tbDEX network.
+For example, Alice's company runs a wallet app for international money transfers, handling various currencies. Each large currency exchange requires a costly and time-consuming KYC check for every customer.To streamline this process and reduce expenses, Alice's company obtains a KYB credential from Bob's Global Exchange, a PFI on the tbDEX network.
 
 In this guide, we'll cover how a PFI (like Bob's company) can issue a KBC to a wallet app (like Alice's) on tbDEX:
 - Designing and issuing a KBC

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -9,6 +9,7 @@ hide_title: true
 # Issuing a Known Business Credential
 
 Known Business Credentials (KBC) are [Verifiable Credentials](/docs/web5/verifiable-credentials/what-are-vcs) designed to streamline the Know Your Business (KYB) process for tbDEX protocol users. 
+
 By issuing this credential, the PFI attests to the business’s legitimacy and compliance with regulations, allowing the PFI to engage in financial activities with the Wallet application without requiring individual KYC for each customer.
 
 

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -25,6 +25,10 @@ If you haven't already, please follow the [Credential Issuance Server Setup Guid
 
 ## Issue Credential
 
+To issue a KBC, call `VerifiableCredential.create()` and pass in the URL to the credential schema the VC is based on. 
+
+We've designed an open source schema for KBCs that you're welcome to use at https://vc.schemas.host/kbc.schema.json.
+
 <Shnip
   snippets={[
     {
@@ -34,7 +38,11 @@ If you haven't already, please follow the [Credential Issuance Server Setup Guid
   ]}
 />
 
-## Specify a KBC as a required claim in an Offering
+## Specify KBC as Requirement
+
+If you issue a KBC to a business, you'll want to specify that credential as a required claim on any applicable Offerings you may provide. 
+
+You can do this via a [Presentation Definition](/docs/web5/verifiable-credentials/presentation-definition) where your input descriptors will specify that the KBC must be issued by your PFI (as noted by your DID URI) and the KBC's credential schema ID must be a specific URL (the one you used to issue the credential).
 
 ### Create Presentation Definition
 
@@ -47,7 +55,9 @@ If you haven't already, please follow the [Credential Issuance Server Setup Guid
   ]}
 />
 
-### Specify required claim in Offering
+## Add Required Claim to Offering
+
+Now that you've defined your requirements, you can add them to any relevant Offerings.
 
 <Shnip
   snippets={[

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -9,7 +9,7 @@ hide_title: true
 # Issuing a Known Business Credential
 
 Known Business Credentials (KBC) are [Verifiable Credentials](/docs/web5/verifiable-credentials/what-are-vcs) designed to streamline the Know Your Business (KYB) process for tbDEX protocol users. 
-KBCs help businesses gain access to PFIs providing regulated financial services. 
+By issuing this credential, the PFI attests to the business’s legitimacy and compliance with regulations, allowing the PFI to engage in financial activities with the Wallet application without requiring individual KYC for each customer.
 
 This guide is intended for PFIs that are using tbDEX to transact with other known businesses, without directly onboarding those businesses’ customers."
 

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -42,7 +42,7 @@ We've designed an open source schema for KBCs that you're welcome to use at http
 
 ## Specify KBC as Requirement
 
-If you issue a KBC to a business, you'll want to specify that credential as a required claim on any applicable Offerings you may provide. 
+If you issue a KBC to a business, you'll want to specify that credential as a [required claim](/docs/tbdex/pfi/creating-offerings#required-claims) on any applicable Offerings you may provide. 
 
 You can do this via a [Presentation Definition](/docs/web5/verifiable-credentials/presentation-definition) where your input descriptors will specify that the KBC must be issued by your PFI (as noted by your DID URI) and the KBC's credential schema ID must be a specific URL (the one you used to issue the credential).
 

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -59,6 +59,10 @@ The `id` property is a string that uniquely identifies the `input_descriptor`. I
     {
       snippetName: 'kbcPresentationDefinitionJs',
       language: 'JavaScript',
+    },
+    {
+      snippetName: 'kbcPresentationDefinitionKt',
+      language: 'Kotlin',
     }
   ]}
 />
@@ -72,6 +76,10 @@ Now that you've defined your requirements, you can add them to any relevant Offe
     {
       snippetName: 'kbcCreateOfferingJs',
       language: 'JavaScript',
-    }
+    },
+        {
+      snippetName: 'kbcCreateOfferingKt',
+      language: 'Kotlin',
+    },
   ]}
 />

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -33,6 +33,18 @@ In this guide, we'll cover how to:
     { snippetName: 'importKnownBusinessCredentialJs', language: 'JavaScript'},
 ]} />
 
+## Design Known Business Credential
+When creating a Verifiable Credential, you can design a model class to represent the specific type of credential you'd like to issue.
+When defining a KbcCredential, you'll need to specify an `id` and a `credentialSchema`.
+<Shnip
+  snippets={[
+    {
+      snippetName: 'kbcCredentialClass',
+      language: 'JavaScript',
+    }
+  ]}
+/>
+
 ## Issue and Sign Credential
 
 <Shnip

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -23,7 +23,7 @@ In this guide, we'll cover how to:
 
 ## Environment Setup
 
-If you haven't already, please follow the [Credential Issuance Server Setup Guide](/docs/tbdex/issuer/vc-serverSetup) for detailed instructions on the dependencies and packages needed to set up your server
+If you haven't already, please follow the [Credential Issuance Server Setup Guide](/docs/tbdex/issuer/vc-serverSetup) for detailed instructions on the dependencies and packages needed to set up your server.
 
 ## Issue Credential
 

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -16,9 +16,9 @@ By issuing this credential, the PFI attests to the business’s legitimacy and c
 This guide is intended for educational purposes only and does not constitute legal advice. Compliance programs may have varying requirements. Consult your legal and/or compliance advisors to ensure that the KBC is consistent with your legal and compliance obligations.
 :::
 
-Alice runs a wallet app for money transfers that handles various currencies. To exchange large amounts quickly without repeated lengthy checks, the company obtains a Known Business Credential from Bob's company, a Participating Financial Institution (PFI) on the tbDEX network. 
+Alice's company runs a wallet app for international money transfers, handling various currencies. Currently, each large currency exchange requires a costly and time-consuming KYC check for every customer. To streamline this process and reduce expenses, Alice's company decides to obtain a KYB credential from Bob's Global Exchange, a Participating Financial Institution (PFI) on the tbDEX network
 
-In this guide, we'll walk through how Bob's PFI sets up Alice's wallet business on tbDEX by covering:
+In this guide, we'll walk through how Bob's PFI can set up Alice's wallet business on tbDEX by covering:
 - Designing and issuing a KBC
 - Specifying a KBC as a required claim in an [Offering](/docs/tbdex/pfi/creating-offerings)
 

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -21,6 +21,7 @@ In this guide, we'll cover how to:
 - Specify a KBC as a required claim in an [Offering](/docs/tbdex/pfi/creating-offerings)
 
 ## Environment Setup
+
 If you haven't already, please follow the [Credential Issuance Server Setup Guide](/docs/tbdex/issuer/vc-serverSetup) for detailed instructions on the dependencies and packages needed to set up your server
 
 ## Issue Credential
@@ -43,6 +44,10 @@ We've designed an open source schema for KBCs that you're welcome to use at http
 If you issue a KBC to a business, you'll want to specify that credential as a required claim on any applicable Offerings you may provide. 
 
 You can do this via a [Presentation Definition](/docs/web5/verifiable-credentials/presentation-definition) where your input descriptors will specify that the KBC must be issued by your PFI (as noted by your DID URI) and the KBC's credential schema ID must be a specific URL (the one you used to issue the credential).
+
+:::note
+The `id` property is a string that uniquely identifies the `input_descriptor`. It is required and must be unique within the `presentation_definition`.
+:::
 
 ### Create Presentation Definition
 

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -17,7 +17,6 @@ This guide is intended for educational purposes only and does not constitute leg
 :::
 
 ## TL;DR
-For example, Alice's company runs a wallet app for international money transfers, handling various currencies. Each large currency exchange requires a costly and time-consuming KYC check for every customer.To streamline this process and reduce expenses, Alice's company obtains a KYB credential from Bob's Global Exchange, a PFI on the tbDEX network.
 
 In this guide, we'll cover how a PFI (like Bob's company) can issue a KBC to a wallet app (like Alice's) on tbDEX:
 - Designing and issuing a KBC

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -16,7 +16,7 @@ By issuing this credential, the PFI attests to the business’s legitimacy and c
 This guide is intended for educational purposes only and does not constitute legal advice. Compliance programs may have varying requirements. Consult your legal and/or compliance advisors to ensure that the KBC is consistent with your legal and compliance obligations.
 :::
 
-Alice runs a wallet app for money transfers that handles various currencies. To exchange large amounts quickly without repeated lengthy checks, Alice gets a Known Business Credential from Bob's company, a Participating Financial Institution (PFI) on the tbDEX network.
+Alice runs a wallet app for money transfers that handles various currencies. To exchange large amounts quickly without repeated lengthy checks, the company obtains a Known Business Credential from Bob's company, a Participating Financial Institution (PFI) on the tbDEX network. 
 
 In this guide, we'll walk through how Bob's PFI sets up Alice's wallet business on tbDEX by covering:
 - Designing and issuing a KBC

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -45,6 +45,8 @@ We've designed an open source schema for KBCs that you're welcome to use at http
   ]}
 />
 
+In the example above, `signedKbc` is a [token](/docs/web5/verifiable-credentials/jwt-to-vc#what-is-a-jwt) that you can safely provide to the business you're issuing the KBC to.
+
 ## Specify KBC as Requirement
 
 If you issue a KBC to a business, you'll want to specify that credential as a [required claim](/docs/tbdex/pfi/creating-offerings#required-claims) on any applicable Offerings you may provide. 

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -1,0 +1,69 @@
+---
+sidebar_position: 1
+title: Issuing a KBC
+hide_title: true
+---
+
+<LanguageSwitcher languages="JavaScript, Kotlin" />
+
+# Issuing a Known Business Credential
+
+Known Business Credentials (KBC) are [Verifiable Credentials](/docs/web5/verifiable-credentials/what-are-vcs) designed to streamline the Know Your Business (KYB) process for tbDEX protocol users. 
+KBCs help businesses gain access to PFIs providing regulated financial services. 
+
+This guide is intended for PFIs that are using tbDEX to transact with other known businesses, without directly onboarding those businesses’ customers."
+
+:::danger Important
+This guide is intended for educational purposes only and does not constitute legal advice. Compliance programs may have varying requirements. Consult your legal and/or compliance advisors to ensure that the KBC is consistent with your legal and compliance obligations.
+:::
+
+In this guide, we'll cover how to:
+- Design and issue a KBC
+- Specify a KBC as a required claim in an [Offering](https://developer.tbd.website/docs/tbdex/pfi/creating-offerings)
+
+## Install packages
+
+<Dependencies languageDependencies={[
+  { language: 'javascript', dependencies: ['@web5/credentials', '@web5/dids'] },
+]}/>
+
+## Import Classes
+
+<Shnip snippets={[
+    { snippetName: 'importKnownBusinessCredentialJs', language: 'JavaScript'},
+]} />
+
+## Issue and Sign Credential
+
+<Shnip
+  snippets={[
+    {
+      snippetName: 'issueKbcJs',
+      language: 'JavaScript',
+    }
+  ]}
+/>
+
+## Specify a KBC as a required claim in an Offering
+
+### Create Presentation Definition
+
+<Shnip
+  snippets={[
+    {
+      snippetName: 'kbcPresentationDefinitionJs',
+      language: 'JavaScript',
+    }
+  ]}
+/>
+
+### Specify required claim in Offering
+
+<Shnip
+  snippets={[
+    {
+      snippetName: 'kbcCreateOfferingJs',
+      language: 'JavaScript',
+    }
+  ]}
+/>

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -36,6 +36,10 @@ We've designed an open source schema for KBCs that you're welcome to use at http
     {
       snippetName: 'issueKbcJs',
       language: 'JavaScript',
+    },
+    {
+      snippetName: 'issueKbcKt',
+      language: 'Kotlin',
     }
   ]}
 />

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -16,9 +16,10 @@ By issuing this credential, the PFI attests to the business’s legitimacy and c
 This guide is intended for educational purposes only and does not constitute legal advice. Compliance programs may have varying requirements. Consult your legal and/or compliance advisors to ensure that the KBC is consistent with your legal and compliance obligations.
 :::
 
-Alice's company runs a wallet app for international money transfers, handling various currencies. Currently, each large currency exchange requires a costly and time-consuming KYC check for every customer. To streamline this process and reduce expenses, Alice's company decides to obtain a KYB credential from Bob's Global Exchange, a Participating Financial Institution (PFI) on the tbDEX network
+## TL;DR
+For example, Alice's company runs a wallet app for international money transfers, handling various currencies. Currently, each large currency exchange requires a costly and time-consuming KYC check for every customer. To streamline this process and reduce expenses, Alice's company decides to obtain a KYB credential from Bob's Global Exchange, a Participating Financial Institution (PFI) on the tbDEX network.
 
-In this guide, we'll walk through how Bob's PFI can set up Alice's wallet business on tbDEX by covering:
+In this guide, we'll cover how a PFI (like Bob's company) can issue a KBC to a wallet app (like Alice's) on tbDEX:
 - Designing and issuing a KBC
 - Specifying a KBC as a required claim in an [Offering](/docs/tbdex/pfi/creating-offerings)
 

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -18,21 +18,13 @@ This guide is intended for educational purposes only and does not constitute leg
 
 In this guide, we'll cover how to:
 - Design and issue a KBC
-- Specify a KBC as a required claim in an [Offering](https://developer.tbd.website/docs/tbdex/pfi/creating-offerings)
+- Specify a KBC as a required claim in an [Offering](/docs/tbdex/pfi/creating-offerings)
 
-## Install packages
-
-<Dependencies languageDependencies={[
-  { language: 'javascript', dependencies: ['@web5/credentials', '@web5/dids'] },
-]}/>
-
-## Import Classes
-
-<Shnip snippets={[
-    { snippetName: 'importKnownBusinessCredentialJs', language: 'JavaScript'},
-]} />
+## Environment Setup
+If you haven't already, please follow the [Credential Issuance Server Setup Guide](/docs/tbdex/issuer/vc-serverSetup) for detailed instructions on the dependencies and packages needed to set up your server
 
 ## Design Known Business Credential
+
 When creating a Verifiable Credential, you can design a model class to represent the specific type of credential you'd like to issue.
 When defining a KbcCredential, you'll need to specify an `id` and a `credentialSchema`.
 <Shnip

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -23,20 +23,7 @@ In this guide, we'll cover how to:
 ## Environment Setup
 If you haven't already, please follow the [Credential Issuance Server Setup Guide](/docs/tbdex/issuer/vc-serverSetup) for detailed instructions on the dependencies and packages needed to set up your server
 
-## Design Known Business Credential
-
-When creating a Verifiable Credential, you can design a model class to represent the specific type of credential you'd like to issue.
-When defining a KbcCredential, you'll need to specify an `id` and a `credentialSchema`.
-<Shnip
-  snippets={[
-    {
-      snippetName: 'kbcCredentialClass',
-      language: 'JavaScript',
-    }
-  ]}
-/>
-
-## Issue and Sign Credential
+## Issue Credential
 
 <Shnip
   snippets={[

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -48,8 +48,6 @@ We've designed an open source schema for KBCs that you're welcome to use at http
 
 If you issue a KBC to a business, you'll want to specify that credential as a [required claim](/docs/tbdex/pfi/creating-offerings#required-claims) on any applicable Offerings you may provide. 
 
-You can do this via a [Presentation Definition](/docs/web5/verifiable-credentials/presentation-definition) where your input descriptors will specify that the KBC must be issued by your PFI (as noted by your DID URI) and the KBC's credential schema ID must be a specific URL (the one you used to issue the credential).
-
 :::note
 The `id` property is a string that uniquely identifies the `input_descriptor`. It is required and must be unique within the `presentation_definition`.
 :::

--- a/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
+++ b/site/docs/tbdex/issuer/kbc/kbc-issuer.mdx
@@ -12,14 +12,15 @@ Known Business Credentials (KBC) are [Verifiable Credentials](/docs/web5/verifia
 
 By issuing this credential, the PFI attests to the business’s legitimacy and compliance with regulations, allowing the PFI to engage in financial activities with the Wallet application without requiring individual KYC for each customer.
 
-
 :::danger Important
 This guide is intended for educational purposes only and does not constitute legal advice. Compliance programs may have varying requirements. Consult your legal and/or compliance advisors to ensure that the KBC is consistent with your legal and compliance obligations.
 :::
 
-In this guide, we'll cover how to:
-- Design and issue a KBC
-- Specify a KBC as a required claim in an [Offering](/docs/tbdex/pfi/creating-offerings)
+Alice runs a wallet app for money transfers that handles various currencies. To exchange large amounts quickly without repeated lengthy checks, Alice gets a Known Business Credential from Bob's company, a Participating Financial Institution (PFI) on the tbDEX network.
+
+In this guide, we'll walk through how Bob's PFI sets up Alice's wallet business on tbDEX by covering:
+- Designing and issuing a KBC
+- Specifying a KBC as a required claim in an [Offering](/docs/tbdex/pfi/creating-offerings)
 
 ## Environment Setup
 

--- a/site/docs/tbdex/issuer/overview.mdx
+++ b/site/docs/tbdex/issuer/overview.mdx
@@ -39,3 +39,4 @@ The Credential Issuer guides are intended to provide you with what you need to b
 2. [Server Setup](/docs/tbdex/issuer/vc-serverSetup)
 3. [Credential Issuance](/docs/tbdex/issuer/vc-issuance)
 4. [Issuing a Known Customer Credential](/docs/tbdex/issuer/kcc/kcc-issuer)
+5. [Issuing a Known Business Credential](/docs/tbdex/issuer/kbc/kbc-issuer)

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -33,6 +33,7 @@ describe("Known Business Credential", () => {
                 id: "https://vc.schemas.host/kbc.schema.json"
             }
         })
+        const signedKbc = await kbc.sign({ did: pfiDid });
         // :snippet-end:
         expect(kbc).toBeDefined();
         expect.soft(kbc).toHaveProperty('issuer', pfiDid.uri);

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -90,36 +90,14 @@ describe("Known Business Credential", () => {
                     description: "Selling BTC for USD",
                     payin: {
                         currencyCode: "USD",
-                        methods: [{
-                            kind: "DEBIT_CARD",
-                            requiredPaymentDetails: {
-                                "$schema": "http://json-schema.org/draft-07/schema",
-                                "type": "object",
-                                "properties": {
-                                    "cardNumber": {
-                                        "type": "string",
-                                        "description": "The 16-digit debit card number",
-                                        "minLength": 16,
-                                        "maxLength": 16
-                                    },
-                                    "expiryDate": {
-                                        "type": "string",
-                                        "description": "The expiry date of the card in MM/YY format",
-                                        "pattern": "^(0[1-9]|1[0-2])\\/([0-9]{2})$"
-                                    },
-                                    "cardHolderName": {
-                                        "type": "string",
-                                        "description": "Name of the cardholder as it appears on the card"
-                                    },
-                                    "cvv": {
-                                        "type": "string",
-                                        "description": "The 3-digit CVV code",
-                                        "minLength": 3,
-                                        "maxLength": 3
-                                    }
-                                }
-                            }
-                        }]
+                        max: "100.00",
+                        methods: [
+                          {
+                            description: "Pay in via Debit Card, Apple Pay, or CashApp Pay",
+                            kind: "PAYMENT_LINK",
+                            name: "Debit Card, ApplePay, CashApp Pay"
+                          }
+                        ]
                     },
                     payout: {
                         currencyCode: 'BTC',

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -24,13 +24,13 @@ describe("Known Business Credential", () => {
     test("Issue Known Business Credential", async () => {
         // :snippet-start: issueKbcJs
         const kbc = await VerifiableCredential.create({
-            issuer: pfiDid.uri,
-            subject: subjectDidUri,
-            expirationDate: '2025-09-30T12:34:56Z',
+            issuer: pfiDid.uri, // Issuer's DID URI
+            subject: subjectDidUri, // Wallet app's DID URI
+            expirationDate: '2025-09-30T12:34:56Z', // Date the KBC should expire
             data: {},
             credentialSchema: {
-                type: "JsonSchema",
-                id: "https://vc.schemas.host/kbc.schema.json"
+                type: "JsonSchema", // Format type of the schema used for the KBC
+                id: "https://vc.schemas.host/kbc.schema.json" // URL to the schema used for the KBC
             }
         })
         const signedKbc = await kbc.sign({ did: pfiDid });

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -54,7 +54,7 @@ describe("Known Business Credential", () => {
             },
             input_descriptors: [
                 {
-                    id: "known-business-credential",
+                    id: "known-business-credential_1", // required unique id for the input descriptor
                     name: "Known Business Credential",
                     purpose: "Please present your Known Business Credential for verification.",
                     constraints: {
@@ -75,7 +75,6 @@ describe("Known Business Credential", () => {
                             }
                         ]
                     },
-                    id: "1" // required unique id for the input descriptor
                 }
             ]
         };
@@ -118,7 +117,7 @@ describe("Known Business Credential", () => {
 
             await offering.sign(pfiDid);
             offering.validate();
-            
+
             // :snippet-end:
 
         } catch (e) {

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -35,7 +35,7 @@ describe("Known Business Credential", () => {
         // :snippet-end:
 
         // :snippet-start: issueKbcJs
-        const vc = await VerifiableCredential.create({
+        const kbc = await VerifiableCredential.create({
             issuer: pfiDid.uri,
             subject: subjectDid.uri,
             expirationDate: '2025-09-30T12:34:56Z',
@@ -47,11 +47,11 @@ describe("Known Business Credential", () => {
                 },
             )
         });
-        const signedVc = await vc.sign({ did: pfiDid })
+        const signedKbc = await vc.sign({ did: pfiDid })
         // :snippet-end:
-        expect(vc).toBeDefined();
-        expect.soft(vc).toHaveProperty('issuer', pfiDid.uri);
-        expect(typeof signedVc).toBe('string');
+        expect(kbc).toBeDefined();
+        expect.soft(kbc).toHaveProperty('issuer', pfiDid.uri);
+        expect(typeof signedKbc).toBe('string');
 
     })
 

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -45,7 +45,7 @@ describe("Known Business Credential", () => {
                 },
             )
         });
-        const signedKbc = await vc.sign({ did: pfiDid })
+        const signedKbc = await kbc.sign({ did: pfiDid })
         // :snippet-end:
         expect(kbc).toBeDefined();
         expect.soft(kbc).toHaveProperty('issuer', pfiDid.uri);

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -1,0 +1,157 @@
+import { describe, test, expect, beforeAll } from 'vitest';
+// :snippet-start: importKnownBusinessCredentialJs
+import { VerifiableCredential } from '@web5/credentials';
+import { DidDht } from '@web5/dids';
+import { Offering } from '@tbdex/http-client';
+// :snippet-end:
+
+describe("Known Business Credential", () => {
+    let pfiDid;
+    let subjectDid;
+    beforeAll(async () => {
+        pfiDid = await DidDht.create({
+            options: {
+                publish: true,
+                services: [{
+                    id: 'pfi',
+                    type: 'PFI',
+                    serviceEndpoint: 'https://example.com/'
+                }]
+            },
+        })
+        subjectDid = await DidDht.create()
+    })
+
+    test("Issue and Sign Known Business Credential", async () => {
+        // :snippet-start: issueKbcJs
+        const vc = await VerifiableCredential.create({
+            issuer: pfiDid.uri,
+            subject: subjectDid.uri,
+            expirationDate: '2025-09-30T12:34:56Z',
+            data: {
+                id: subjectDid.uri
+            },
+            credentialSchema: {
+                type: "JsonSchema",
+                id: "https://vc.schemas.host/kbc.schema.json"
+            }
+        });
+        const signedVc = await vc.sign({ did: pfiDid })
+        // :snippet-end:
+        expect(vc).toBeDefined();
+        expect.soft(vc).toHaveProperty('issuer', pfiDid.uri);
+        expect(typeof signedVc).toBe('string');
+
+    })
+
+    test("Required claims in Known Business Credential", async () => {
+        // :snippet-start: kbcPresentationDefinitionJs
+        const pd = {
+            id: "presentation-definition-kbc",
+            name: "KYB Verification",
+            purpose: "Verifiying your business status.",
+            format: {
+                jwt_vc: {
+                    alg: ["ES256K", "EdDSA"]
+                }
+            },
+            input_descriptors: [
+                {
+                    id: "known-business-credential",
+                    name: "Known Business Credential",
+                    purpose: "Please present your Known Business Credential for verification.",
+                    constraints: {
+                        fields: [
+                            {
+                                path: ["$.credentialSchema.id"],
+                                filter: {
+                                    type: "string",
+                                    const: "https://vc.schemas.host/kbc.schema.json"
+                                }
+                            },
+                            {
+                                path: ["$.issuer"],
+                                filter: {
+                                    type: "string",
+                                    const: pfiDid.uri
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        };
+        // :snippet-end:
+
+        try{
+            // :snippet-start: kbcCreateOfferingJs
+            const offering = Offering.create({
+                metadata: {
+                    from: pfiDid.uri,
+                    protocol: "1.0"
+                },
+                data: {
+                    description: "Selling BTC for USD",
+                    payin: {
+                        currencyCode: "USD",
+                        methods: [{
+                          kind: "DEBIT_CARD",
+                          requiredPaymentDetails: {
+                              "$schema": "http://json-schema.org/draft-07/schema",
+                              "type": "object",
+                              "properties": {
+                                  "cardNumber": {
+                                      "type": "string",
+                                      "description": "The 16-digit debit card number",
+                                      "minLength": 16,
+                                      "maxLength": 16
+                                  },
+                                  "expiryDate": {
+                                      "type": "string",
+                                      "description": "The expiry date of the card in MM/YY format",
+                                      "pattern": "^(0[1-9]|1[0-2])\\/([0-9]{2})$"
+                                  },
+                                  "cardHolderName": {
+                                      "type": "string",
+                                      "description": "Name of the cardholder as it appears on the card"
+                                  },
+                                  "cvv": {
+                                      "type": "string",
+                                      "description": "The 3-digit CVV code",
+                                      "minLength": 3,
+                                      "maxLength": 3
+                                  }
+                              }
+                          }
+                        }]
+                    },
+                    payout: {
+                        currencyCode: 'BTC',
+                        methods: [
+                            {
+                                kind: 'BTC_ADDRESS',
+                                estimatedSettlementTime: 60,
+                                fee: '0.25',
+                            }
+                        ]
+                    },
+                    payoutUnitsPerPayinUnit: '0.00003826',  
+                    // highlight-next-line
+                    requiredClaims: pd
+                }
+            });
+            // :snippet-end:
+
+        
+            await offering.sign(pfiDid);
+
+            offering.validate();
+    
+        } catch(e) {
+            expect.fail(e.message)
+        }
+    })
+
+    
+
+    })

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -67,7 +67,7 @@ describe("Known Business Credential", () => {
                                 }
                             },
                             {
-                                path: ["$.issuer"],
+                                path: ["$.vc.issuer"],
                                 filter: {
                                     type: "string",
                                     const: pfiDid.uri

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -60,7 +60,7 @@ describe("Known Business Credential", () => {
                     constraints: {
                         fields: [
                             {
-                                path: ["$.credentialSchema.id"],
+                                path: ["$.vc.credentialSchema[0].id"],
                                 filter: {
                                     type: "string",
                                     const: "https://vc.schemas.host/kbc.schema.json"

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -23,18 +23,29 @@ describe("Known Business Credential", () => {
     })
 
     test("Issue and Sign Known Business Credential", async () => {
+        // :snippet-start: kbcCredentialClass
+        class KbcCredential {
+            constructor(id, credentialSchema) {
+                this.data = {
+                    id: id
+                };
+                this.credentialSchema = credentialSchema;
+            }
+        }
+        // :snippet-end:
+
         // :snippet-start: issueKbcJs
         const vc = await VerifiableCredential.create({
             issuer: pfiDid.uri,
             subject: subjectDid.uri,
             expirationDate: '2025-09-30T12:34:56Z',
-            data: {
-                id: subjectDid.uri
-            },
-            credentialSchema: {
-                type: "JsonSchema",
-                id: "https://vc.schemas.host/kbc.schema.json"
-            }
+            data: new KbcCredential(
+                subjectDid.uri,
+                {
+                    type: "JsonSchema",
+                    id: "https://vc.schemas.host/kbc.schema.json"
+                },
+            )
         });
         const signedVc = await vc.sign({ did: pfiDid })
         // :snippet-end:
@@ -83,7 +94,7 @@ describe("Known Business Credential", () => {
         };
         // :snippet-end:
 
-        try{
+        try {
             // :snippet-start: kbcCreateOfferingJs
             const offering = Offering.create({
                 metadata: {
@@ -95,34 +106,34 @@ describe("Known Business Credential", () => {
                     payin: {
                         currencyCode: "USD",
                         methods: [{
-                          kind: "DEBIT_CARD",
-                          requiredPaymentDetails: {
-                              "$schema": "http://json-schema.org/draft-07/schema",
-                              "type": "object",
-                              "properties": {
-                                  "cardNumber": {
-                                      "type": "string",
-                                      "description": "The 16-digit debit card number",
-                                      "minLength": 16,
-                                      "maxLength": 16
-                                  },
-                                  "expiryDate": {
-                                      "type": "string",
-                                      "description": "The expiry date of the card in MM/YY format",
-                                      "pattern": "^(0[1-9]|1[0-2])\\/([0-9]{2})$"
-                                  },
-                                  "cardHolderName": {
-                                      "type": "string",
-                                      "description": "Name of the cardholder as it appears on the card"
-                                  },
-                                  "cvv": {
-                                      "type": "string",
-                                      "description": "The 3-digit CVV code",
-                                      "minLength": 3,
-                                      "maxLength": 3
-                                  }
-                              }
-                          }
+                            kind: "DEBIT_CARD",
+                            requiredPaymentDetails: {
+                                "$schema": "http://json-schema.org/draft-07/schema",
+                                "type": "object",
+                                "properties": {
+                                    "cardNumber": {
+                                        "type": "string",
+                                        "description": "The 16-digit debit card number",
+                                        "minLength": 16,
+                                        "maxLength": 16
+                                    },
+                                    "expiryDate": {
+                                        "type": "string",
+                                        "description": "The expiry date of the card in MM/YY format",
+                                        "pattern": "^(0[1-9]|1[0-2])\\/([0-9]{2})$"
+                                    },
+                                    "cardHolderName": {
+                                        "type": "string",
+                                        "description": "Name of the cardholder as it appears on the card"
+                                    },
+                                    "cvv": {
+                                        "type": "string",
+                                        "description": "The 3-digit CVV code",
+                                        "minLength": 3,
+                                        "maxLength": 3
+                                    }
+                                }
+                            }
                         }]
                     },
                     payout: {
@@ -135,23 +146,23 @@ describe("Known Business Credential", () => {
                             }
                         ]
                     },
-                    payoutUnitsPerPayinUnit: '0.00003826',  
+                    payoutUnitsPerPayinUnit: '0.00003826',
                     // highlight-next-line
                     requiredClaims: pd
                 }
             });
             // :snippet-end:
 
-        
+
             await offering.sign(pfiDid);
 
             offering.validate();
-    
-        } catch(e) {
+
+        } catch (e) {
             expect.fail(e.message)
         }
     })
 
-    
 
-    })
+
+})

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -44,7 +44,7 @@ describe("Known Business Credential", () => {
     test("Required claims in Known Business Credential", async () => {
         // :snippet-start: kbcPresentationDefinitionJs
         const pd = {
-            id: "presentation-definition-kbc",
+            id: "presentation-definition-kbc", // required unique id for presentation definition
             name: "KYB Verification",
             purpose: "Verifiying your business status.",
             format: {
@@ -74,7 +74,8 @@ describe("Known Business Credential", () => {
                                 }
                             }
                         ]
-                    }
+                    },
+                    id: "1" // required unique id for the input descriptor
                 }
             ]
         };

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -27,7 +27,9 @@ describe("Known Business Credential", () => {
             issuer: pfiDid.uri, // Issuer's DID URI
             subject: subjectDidUri, // Wallet app's DID URI
             expirationDate: '2025-09-30T12:34:56Z', // Date the KBC should expire
-            data: {}, // Optional: Custom attributes for the KBC
+            data: {
+                //Custom attributes for the KBC 
+                },
             credentialSchema: {
                 type: "JsonSchema", // Format type of the schema used for the KBC
                 id: "https://vc.schemas.host/kbc.schema.json" // URL to the schema used for the KBC

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -115,12 +115,11 @@ describe("Known Business Credential", () => {
                     requiredClaims: pd
                 }
             });
-            // :snippet-end:
-
 
             await offering.sign(pfiDid);
-
             offering.validate();
+            
+            // :snippet-end:
 
         } catch (e) {
             expect.fail(e.message)

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -27,7 +27,7 @@ describe("Known Business Credential", () => {
             issuer: pfiDid.uri, // Issuer's DID URI
             subject: subjectDidUri, // Wallet app's DID URI
             expirationDate: '2025-09-30T12:34:56Z', // Date the KBC should expire
-            data: {},
+            data: {}, // Optional: Custom attributes for the KBC
             credentialSchema: {
                 type: "JsonSchema", // Format type of the schema used for the KBC
                 id: "https://vc.schemas.host/kbc.schema.json" // URL to the schema used for the KBC

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -1,9 +1,7 @@
 import { describe, test, expect, beforeAll } from 'vitest';
-// :snippet-start: importKnownBusinessCredentialJs
 import { VerifiableCredential } from '@web5/credentials';
 import { DidDht } from '@web5/dids';
 import { Offering } from '@tbdex/http-client';
-// :snippet-end:
 
 describe("Known Business Credential", () => {
     let pfiDid;

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -85,7 +85,6 @@ describe("Known Business Credential", () => {
             const offering = Offering.create({
                 metadata: {
                     from: pfiDid.uri,
-                    protocol: "1.0"
                 },
                 data: {
                     description: "Selling BTC for USD",

--- a/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
+++ b/site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js
@@ -5,7 +5,7 @@ import { Offering } from '@tbdex/http-client';
 
 describe("Known Business Credential", () => {
     let pfiDid;
-    let subjectDid;
+    let subjectDidUri;
     beforeAll(async () => {
         pfiDid = await DidDht.create({
             options: {
@@ -17,35 +17,22 @@ describe("Known Business Credential", () => {
                 }]
             },
         })
-        subjectDid = await DidDht.create()
+        const subjectDid = await DidDht.create()
+        subjectDidUri = subjectDid.uri;
     })
 
-    test("Issue and Sign Known Business Credential", async () => {
-        // :snippet-start: kbcCredentialClass
-        class KbcCredential {
-            constructor(id, credentialSchema) {
-                this.data = {
-                    id: id
-                };
-                this.credentialSchema = credentialSchema;
-            }
-        }
-        // :snippet-end:
-
+    test("Issue Known Business Credential", async () => {
         // :snippet-start: issueKbcJs
         const kbc = await VerifiableCredential.create({
             issuer: pfiDid.uri,
-            subject: subjectDid.uri,
+            subject: subjectDidUri,
             expirationDate: '2025-09-30T12:34:56Z',
-            data: new KbcCredential(
-                subjectDid.uri,
-                {
-                    type: "JsonSchema",
-                    id: "https://vc.schemas.host/kbc.schema.json"
-                },
-            )
-        });
-        const signedKbc = await kbc.sign({ did: pfiDid })
+            data: {},
+            credentialSchema: {
+                type: "JsonSchema",
+                id: "https://vc.schemas.host/kbc.schema.json"
+            }
+        })
         // :snippet-end:
         expect(kbc).toBeDefined();
         expect.soft(kbc).toHaveProperty('issuer', pfiDid.uri);
@@ -160,7 +147,4 @@ describe("Known Business Credential", () => {
             expect.fail(e.message)
         }
     })
-
-
-
 })

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
@@ -81,7 +81,7 @@ internal class KbcIssuanceTest {
             ),
             inputDescriptors = listOf(
                 InputDescriptorV2(
-                    id = "known-business-credential", // required unique id for the input descriptor
+                    id = "known-business-credential_1", // required unique id for the input descriptor
                     name = "Known Business Credential",
                     purpose = "Please present your Known Business Credential for verification.",
                     constraints = ConstraintsV2(

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
@@ -58,7 +58,7 @@ internal class KbcIssuanceTest {
                 id = "https://vc.schemas.host/kbc.schema.json" // URL to the schema used for the KBC
             )
         )
-        val signedKbc: String = kbc.sign(pfiDid)
+        val signedKbc = kbc.sign(pfiDid)
         // :snippet-end:
         assertNotNull(kbc)
         assertEquals(pfiDid.uri, kbc.issuer)

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
@@ -9,28 +9,24 @@ import web5.sdk.dids.methods.dht.CreateDidDhtOptions
 import web5.sdk.dids.didcore.Service
 import java.time.Instant
 import web5.sdk.credentials.CredentialSchema
-import java.util.Date
- 
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.*
 import tbdex.sdk.protocol.Parser
 import tbdex.sdk.protocol.Validator
 import tbdex.sdk.protocol.models.*
-import tbdex.sdk.protocol.serialization.Json
-import web5.sdk.credentials.PresentationExchange
 import web5.sdk.credentials.model.*
-import website.tbd.developer.site.docs.utils.TestData
+import java.util.*
 
-import com.fasterxml.jackson.core.JsonParseException
 
 /**
  * Tests backing the KBC Issuance Guide
  */
 internal class KbcIssuanceTest {
-    val objectMapper = ObjectMapper()
+    private val objectMapper = ObjectMapper()
     val pfiDid = DidDht.create(InMemoryKeyManager())
     @Test
-    fun `createEmploymentCredentialKt returns a credential`() {
+    fun `issue KBC`() {
         val serviceToAdd = Service.Builder()
             .id("pfi")
             .type("PFI")
@@ -42,7 +38,7 @@ internal class KbcIssuanceTest {
             services = listOf(serviceToAdd),
         )
 
-        val subjectDid = DidDht.create(InMemoryKeyManager())
+        val subjectDid = DidDht.create(InMemoryKeyManager(),options)
         val subjectDidUri = subjectDid.uri
         data class AdditionalData(
             val exampleField: String = "exampleValue"
@@ -89,13 +85,23 @@ internal class KbcIssuanceTest {
                             FieldV2(
                                 path = listOf("$.credentialSchema.id"),
                                 filterJson = objectMapper.readTree(
-                                    """{"type": "string", "const": "https://vc.schemas.host/kbc.schema.json"}"""
+                                    """
+                                    {
+                                      "type": "string",
+                                      "const": "https://vc.schemas.host/kbc.schema.json"
+                                    }
+                                    """.trimIndent()
                                 ),
                             ),
                             FieldV2(
                                 path = listOf("$.issuer"),
                                 filterJson = objectMapper.readTree(
-                                    """{"type": "string", "const":  "${pfiDid.uri}"}"""
+                                    """
+                                    {
+                                      "type": "string",
+                                      "const":  "${pfiDid.uri}"
+                                    }
+                                    """.trimIndent()
                                 )
                             )
                         )
@@ -143,7 +149,7 @@ internal class KbcIssuanceTest {
             // :snippet-end:
         } catch (e: Exception) {
             Assertions.fail(e.message)
-        }        
+        }
     }
 
 }

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
@@ -1,0 +1,54 @@
+package website.tbd.developer.site.docs.web5.build.verifiablecredentials;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions.*
+import web5.sdk.credentials.VerifiableCredential
+import web5.sdk.crypto.InMemoryKeyManager
+import web5.sdk.dids.methods.dht.DidDht
+import web5.sdk.dids.didcore.Service
+import java.time.Instant
+import web5.sdk.credentials.CredentialSchema
+import java.util.Date
+
+/**
+ * Tests backing the KBC Issuance Guide
+ */
+internal class VcIssuanceTest {
+    @Test
+    fun `createEmploymentCredentialKt returns a credential`() {
+    val serviceToAdd = Service.Builder()
+        .id("pfi")
+        .type("PFI")
+        .serviceEndpoint(listOf("https://example.com/"))
+        .build()
+
+        val options = CreateDidDhtOptions(
+            publish = true,
+            services = listOf(serviceToAdd),
+        )
+
+        val pfiDid = DidDht.create(InMemoryKeyManager())
+        val subjectDid = DidDht.create(InMemoryKeyManager())
+        val subjectDidUri = subjectDid.uri
+
+        // :snippet-start: issueKbcKt
+        val kbc = VerifiableCredential.create(
+            issuer = pfiDid.uri, // Issuers's DID URI
+            subject = subjectDidUri, // Wallet app's DID URI
+            expirationDate = Date.from(Instant.parse("2025-09-30T12:34:56Z")), // Date the KBC should expire
+            data = (), // Optional: Custom attributes for the KBC
+            credentialSchema = CredentialSchema(
+                type: "JsonSchema", // Format type of the schema used for the KBC
+                 id: "https://vc.schemas.host/kbc.schema.json" // URL to the schema used for the KBC
+            )
+        )
+        val signedKbc = kbc.sign(employerDid)
+       // :snippet-end:
+       assertNotNull(vc)
+       assertEquals(employerDid.uri, vc.issuer)
+       assertEquals(employeeDid.uri, vc.subject)
+
+       assertNotNull(signedKbc)
+       assertTrue(signedKbc.matches(Regex("^[a-zA-Z0-9-_]+\\.[a-zA-Z0-9-_]+\\.[a-zA-Z0-9-_]+$")))
+    }
+}

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
@@ -1,54 +1,149 @@
-package website.tbd.developer.site.docs.web5.build.verifiablecredentials;
+package website.tbd.developer.site.docs.web5.build.verifiablecredentials
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 import web5.sdk.credentials.VerifiableCredential
 import web5.sdk.crypto.InMemoryKeyManager
 import web5.sdk.dids.methods.dht.DidDht
+import web5.sdk.dids.methods.dht.CreateDidDhtOptions
 import web5.sdk.dids.didcore.Service
 import java.time.Instant
 import web5.sdk.credentials.CredentialSchema
 import java.util.Date
+ 
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.*
+import tbdex.sdk.protocol.Parser
+import tbdex.sdk.protocol.Validator
+import tbdex.sdk.protocol.models.*
+import tbdex.sdk.protocol.serialization.Json
+import web5.sdk.credentials.PresentationExchange
+import web5.sdk.credentials.model.*
+import website.tbd.developer.site.docs.utils.TestData
+
+import com.fasterxml.jackson.core.JsonParseException
 
 /**
  * Tests backing the KBC Issuance Guide
  */
-internal class VcIssuanceTest {
+internal class KbcIssuanceTest {
+    val objectMapper = ObjectMapper()
+    val pfiDid = DidDht.create(InMemoryKeyManager())
     @Test
     fun `createEmploymentCredentialKt returns a credential`() {
-    val serviceToAdd = Service.Builder()
-        .id("pfi")
-        .type("PFI")
-        .serviceEndpoint(listOf("https://example.com/"))
-        .build()
+        val serviceToAdd = Service.Builder()
+            .id("pfi")
+            .type("PFI")
+            .serviceEndpoint(listOf("https://example.com/"))
+            .build()
 
         val options = CreateDidDhtOptions(
             publish = true,
             services = listOf(serviceToAdd),
         )
 
-        val pfiDid = DidDht.create(InMemoryKeyManager())
         val subjectDid = DidDht.create(InMemoryKeyManager())
         val subjectDidUri = subjectDid.uri
-
+        data class AdditionalData(
+            val exampleField: String = "exampleValue"
+        )
         // :snippet-start: issueKbcKt
         val kbc = VerifiableCredential.create(
-            issuer = pfiDid.uri, // Issuers's DID URI
+            issuer = pfiDid.uri, // Issuer's DID URI
             subject = subjectDidUri, // Wallet app's DID URI
             expirationDate = Date.from(Instant.parse("2025-09-30T12:34:56Z")), // Date the KBC should expire
-            data = (), // Optional: Custom attributes for the KBC
+            data = AdditionalData(), // Custom attributes for the KBC
             credentialSchema = CredentialSchema(
-                type: "JsonSchema", // Format type of the schema used for the KBC
-                 id: "https://vc.schemas.host/kbc.schema.json" // URL to the schema used for the KBC
+                type = "JsonSchema", // Format type of the schema used for the KBC
+                id = "https://vc.schemas.host/kbc.schema.json" // URL to the schema used for the KBC
             )
         )
-        val signedKbc = kbc.sign(employerDid)
-       // :snippet-end:
-       assertNotNull(vc)
-       assertEquals(employerDid.uri, vc.issuer)
-       assertEquals(employeeDid.uri, vc.subject)
+        val signedKbc: String = kbc.sign(pfiDid)
+        // :snippet-end:
+        assertNotNull(kbc)
+        assertEquals(pfiDid.uri, kbc.issuer)
+        assertEquals(subjectDidUri, kbc.subject)
 
-       assertNotNull(signedKbc)
-       assertTrue(signedKbc.matches(Regex("^[a-zA-Z0-9-_]+\\.[a-zA-Z0-9-_]+\\.[a-zA-Z0-9-_]+$")))
+        assertNotNull(signedKbc)
+        assertTrue(signedKbc.matches(Regex("^[a-zA-Z0-9-_]+\\.[a-zA-Z0-9-_]+\\.[a-zA-Z0-9-_]+$")))
     }
+    @Test
+    fun `Required claims in Known Business Credential`() {
+        // :snippet-start: kbcPresentationDefinitionKt
+        val pd = PresentationDefinitionV2(
+            id = "presentation-definition-kbc", // required unique id for presentation definition
+            name = "KYB Verification",
+            purpose = "Verifying your business status.",
+            format = Format(
+                jwtVc = JwtObject(
+                    alg = listOf("ES256K", "EdDSA")
+                )
+            ),
+            inputDescriptors = listOf(
+                InputDescriptorV2(
+                    id = "known-business-credential", // required unique id for the input descriptor
+                    name = "Known Business Credential",
+                    purpose = "Please present your Known Business Credential for verification.",
+                    constraints = ConstraintsV2(
+                        fields = listOf(
+                            FieldV2(
+                                path = listOf("$.credentialSchema.id"),
+                                filterJson = objectMapper.readTree(
+                                    """{"type": "string", "const": "https://vc.schemas.host/kbc.schema.json"}"""
+                                ),
+                            ),
+                            FieldV2(
+                                path = listOf("$.issuer"),
+                                filterJson = objectMapper.readTree(
+                                    """{"type": "string", "const":  "${pfiDid.uri}"}"""
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        // :snippet-end:
+
+        try {
+             // :snippet-start: kbcCreateOfferingKt
+            val offering = Offering.create(
+                from = pfiDid.uri,
+                data = OfferingData(
+                    description = "Selling BTC for USD",
+                    payin = PayinDetails(
+                        currencyCode = "USD",
+                        max = "100.00",
+                        methods = listOf(
+                            PayinMethod(
+                                description = "Pay in via Debit Card, Apple Pay, or CashApp Pay",
+                                kind = "PAYMENT_LINK",
+                                name = "Debit Card, ApplePay, CashApp Pay"
+                            )
+                        )
+                    ),
+                    payout = PayoutDetails(
+                        currencyCode = "BTC",
+                        methods = listOf(
+                            PayoutMethod(
+                                kind = "BTC_ADDRESS",
+                                estimatedSettlementTime = 60,
+                                fee = "0.25"
+                            )
+                        )
+                    ),
+                    payoutUnitsPerPayinUnit = "0.00003826",
+                    // highlight-next-line
+                    requiredClaims = pd
+                )
+            )
+
+            offering.sign(pfiDid)
+            Validator.validate(Parser.parseResourceToJsonNode(offering.toString()), "resource")
+            // :snippet-end:
+        } catch (e: Exception) {
+            Assertions.fail(e.message)
+        }        
+    }
+
 }

--- a/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
+++ b/site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt
@@ -24,20 +24,22 @@ import java.util.*
  */
 internal class KbcIssuanceTest {
     private val objectMapper = ObjectMapper()
-    val pfiDid = DidDht.create(InMemoryKeyManager())
+   
+    val serviceToAdd = Service.Builder()
+        .id("pfi")
+        .type("PFI")
+        .serviceEndpoint(listOf("https://example.com/"))
+        .build()
+
+    val options = CreateDidDhtOptions(
+        publish = true,
+        services = listOf(serviceToAdd),
+    )
+
+    val pfiDid = DidDht.create(InMemoryKeyManager(), options)
+
     @Test
     fun `issue KBC`() {
-        val serviceToAdd = Service.Builder()
-            .id("pfi")
-            .type("PFI")
-            .serviceEndpoint(listOf("https://example.com/"))
-            .build()
-
-        val options = CreateDidDhtOptions(
-            publish = true,
-            services = listOf(serviceToAdd),
-        )
-
         val subjectDid = DidDht.create(InMemoryKeyManager(),options)
         val subjectDidUri = subjectDid.uri
         data class AdditionalData(


### PR DESCRIPTION
https://deploy-preview-1526--tbd-website-developer.netlify.app/docs/tbdex/issuer/kbc/kbc-issuer

This pull request introduces documentation and test updates for issuing Known Business Credentials (KBC) in the tbDEX protocol. The changes include new documentation for the KBC issuer, along with corresponding JavaScript and Kotlin test cases to validate the KBC issuance process.

### Documentation Updates:
* [`site/docs/tbdex/issuer/kbc/_category_.json`](diffhunk://#diff-280b9c19d73d1a5524b6482659c6401098c60caa142967ed195d4723588184d6R1-R5): Added a new category for Known Business Credential with a specified position.
* [`site/docs/tbdex/issuer/kbc/kbc-issuer.mdx`](diffhunk://#diff-aacecc7c81e582a8a72c0a6da0564ed75a2c91935a62f092d9ba528d21b4dfeeR1-R88): New documentation page for issuing a Known Business Credential, including environment setup, credential issuance, and specifying KBC as a required claim.

### Test Updates:
* [`site/testsuites/testsuite-javascript/__tests__/tbdex/issuer/kbc/knownBusinessCredentialIssuer.test.js`](diffhunk://#diff-fd39c593f6a73793e00f7781642ee2916efd5487d4e3909011a85fac8980b244R1-R129): Added JavaScript tests for issuing a Known Business Credential and specifying required claims.
* [`site/testsuites/testsuite-kotlin/src/test/kotlin/docs/tbdex/issuer/kbc/KnownBusinessCredentialIssuerTest.kt`](diffhunk://#diff-5889aa35788ca9de05b43afdef1f4910950c1ad7ce74148f155bcd7ae8e4e34eR1-R149): Added Kotlin tests for issuing a Known Business Credential and specifying required claims.