### PR TITLE
Updated tbDEX and web5 Kotlink SDKs to 2.0.1

### DIFF
--- a/sdk-versions.json
+++ b/sdk-versions.json
@@ -11,9 +11,9 @@
     "@web5/identity-agent": "0.4.0"
   },
   "jvm": {
-    "tbdex": "2.0.0",
-    "web5-credentials": "2.0.0",
-    "web5-dids": "2.0.0",
+    "tbdex": "2.0.1",
+    "web5-credentials": "2.0.1",
+    "web5-dids": "2.0.1",
     "web5-crypto": "2.0.0",
     "web5-keymanager-aws": "2.0.0"
   },

--- a/site/testsuites/testsuite-kotlin/pom.xml
+++ b/site/testsuites/testsuite-kotlin/pom.xml
@@ -15,7 +15,7 @@
     <version.io.ktor>2.3.7</version.io.ktor>
     <version.org.assertj>3.25.2</version.org.assertj>
     <version.org.junit.jupiter>5.10.1</version.org.junit.jupiter>
-    <version.xyz.block.tbdex>2.0.0</version.xyz.block.tbdex>
+    <version.xyz.block.tbdex>2.0.1</version.xyz.block.tbdex>
     <!--
     TODO
     Temp, this should be coming in inherited from dependencyManagement of Web5


### PR DESCRIPTION
2.0.0 had a bug with resolving DHT DIDs. updating site/docs to 2.0.1

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208039801143124