### PR TITLE
updating label to livestreams instead of twitch streams

### DIFF
--- a/propagateSdkVersions.js
+++ b/propagateSdkVersions.js
@@ -7,7 +7,6 @@ const util = require("util");
 const sdkVersionsPath = path.resolve(__dirname, "sdk-versions.json");
 const directoriesToUpdate = [
   __dirname,
-  path.resolve(__dirname, "./examples/tutorials"),
   path.resolve(__dirname, "./site/testsuites"),
 ];
 

--- a/site/src/components/Calendar.jsx
+++ b/site/src/components/Calendar.jsx
@@ -49,7 +49,7 @@ const eventTypes = [
   { label: '👀 Show & Tells', value: '#ShowTell' },
   { label: '🏢 Office Hours', value: '#OfficeHours' },
   { label: '💡 Workshops', value: '#Workshop' },
-  { label: '🎮 Twitch Streams', value: '#TwitchStreams' },
+  { label: '🎮 Live Streams', value: '#LiveStreams' },
   { label: '🎤 Conferences/Talks', value: '#ConferenceTalk' },
 ];
 

--- a/site/src/pages/community/index.js
+++ b/site/src/pages/community/index.js
@@ -225,7 +225,7 @@ function CommunityIndex() {
           Filter through our exciting events: 👀 Show & Tells for project
           highlights, 🏢 Office Hours for open discussions, 💡 Workshops for
           skill-building, 🎮 Live Streams for everything fun. Miss an event?
-          checkout our{' '}
+          Check out our{' '}
           <a
             href="https://www.youtube.com/@tbd.videos"
             target="_blank"

--- a/site/src/pages/community/index.js
+++ b/site/src/pages/community/index.js
@@ -224,7 +224,7 @@ function CommunityIndex() {
         <p className="pb-10">
           Filter through our exciting events: 👀 Show & Tells for project
           highlights, 🏢 Office Hours for open discussions, 💡 Workshops for
-          skill-building, 🎮 Twitch Streams for everything fun. Miss an event?
+          skill-building, 🎮 Live Streams for everything fun. Miss an event?
           checkout our{' '}
           <a
             href="https://www.youtube.com/@tbd.videos"


### PR DESCRIPTION
https://deploy-preview-1545--tbd-website-developer.netlify.app/

This pull request includes several changes to update event labels and remove an outdated directory from the list of directories to update. The most important changes include updating event labels in the calendar component and the community index page, and removing the tutorials directory from the SDK versions update list.

Event label updates:

* [`site/src/components/Calendar.jsx`](diffhunk://#diff-17ee0883106f748f9f394d193501f9b4285f1f3c816dddef21cb8d8d07ad0054L52-R52): Changed the label for Twitch Streams to Live Streams.
* [`site/src/pages/community/index.js`](diffhunk://#diff-96da70c1f6f05e899db6714db92dacd398a02578e3b3fcd345d66c3191efc89eL227-R227): Updated the description to reflect the change from Twitch Streams to Live Streams.

Directory update:

* [`propagateSdkVersions.js`](diffhunk://#diff-69e89764c80bcfd4d1e03c2d8ec893299b781a6667d96d298a5330f7d7a583ecL10): Removed the outdated tutorials directory from the list of directories to update.