### PR TITLE
Add SDK links to project pages

### DIFF
--- a/site/src/components/Actors.jsx
+++ b/site/src/components/Actors.jsx
@@ -25,7 +25,7 @@ const Actors = ({ content }) => {
               </h2>
             </div>
             <p
-              className={`copy text-white flex ${
+              className={`copy primary-white flex ${
                 !content.isWeb5 ? 'ml-[4.375rem]' : ''
               } desktop:ml-0`}
             >
@@ -45,7 +45,7 @@ const Actors = ({ content }) => {
               </h2>
             </div>
             <p
-              className={`copy text-white flex ${
+              className={`copy primary-white flex ${
                 !content.isWeb5 ? 'ml-[4.375rem]' : ''
               } desktop:ml-0`}
             >
@@ -65,7 +65,7 @@ const Actors = ({ content }) => {
               </h2>
             </div>
             <p
-              className={`copy text-white flex ${
+              className={`copy primary-white flex ${
                 !content.isWeb5 ? 'ml-[4.375rem]' : ''
               } desktop:ml-0`}
             >

--- a/site/src/components/Actors.jsx
+++ b/site/src/components/Actors.jsx
@@ -25,7 +25,7 @@ const Actors = ({ content }) => {
               </h2>
             </div>
             <p
-              className={`copy text-primary-yellow flex ${
+              className={`copy text-white flex ${
                 !content.isWeb5 ? 'ml-[4.375rem]' : ''
               } desktop:ml-0`}
             >
@@ -45,7 +45,7 @@ const Actors = ({ content }) => {
               </h2>
             </div>
             <p
-              className={`copy text-primary-yellow flex ${
+              className={`copy text-white flex ${
                 !content.isWeb5 ? 'ml-[4.375rem]' : ''
               } desktop:ml-0`}
             >
@@ -65,7 +65,7 @@ const Actors = ({ content }) => {
               </h2>
             </div>
             <p
-              className={`copy text-primary-yellow flex ${
+              className={`copy text-white flex ${
                 !content.isWeb5 ? 'ml-[4.375rem]' : ''
               } desktop:ml-0`}
             >

--- a/site/src/components/Pillar.jsx
+++ b/site/src/components/Pillar.jsx
@@ -23,11 +23,11 @@ const Pillar = ({ img, title, description, alt }) => {
             <h2 className="text-[1.5rem] text-primary-yellow">{title}</h2>
           </div>
           {typeof description === 'function' ? (
-            <div className="copy text-primary-yellow">
+            <div className="copy text-white">
               <Description />
             </div>
           ) : (
-            <p className="copy text-primary-yellow">{description}</p>
+            <p className="copy text-white">{description}</p>
           )}
         </div>
       </div>

--- a/site/src/components/Pillar.jsx
+++ b/site/src/components/Pillar.jsx
@@ -23,11 +23,11 @@ const Pillar = ({ img, title, description, alt }) => {
             <h2 className="text-[1.5rem] text-primary-yellow">{title}</h2>
           </div>
           {typeof description === 'function' ? (
-            <div className="copy text-white">
+            <div className="copy primary-white">
               <Description />
             </div>
           ) : (
-            <p className="copy text-white">{description}</p>
+            <p className="copy primary-white">{description}</p>
           )}
         </div>
       </div>

--- a/site/src/components/Project.jsx
+++ b/site/src/components/Project.jsx
@@ -25,7 +25,7 @@ const Project = ({
             <Description />
           </div>
         ) : (
-          <p className="copy text-primary-yellow my-0">{description}</p>
+          <p className="copy text-white my-0">{description}</p>
         )}
       </div>
       <div>

--- a/site/src/components/Project.jsx
+++ b/site/src/components/Project.jsx
@@ -21,11 +21,11 @@ const Project = ({
       </div>
       <div className="pb-9 tablet:pb-[67px] tablet:grow">
         {typeof description === 'function' ? (
-          <div className="copy text-primary-yellow my-0">
+          <div className="copy primary-white my-0">
             <Description />
           </div>
         ) : (
-          <p className="copy text-white my-0">{description}</p>
+          <p className="copy primary-white my-0">{description}</p>
         )}
       </div>
       <div>

--- a/site/src/components/SdkCard.jsx
+++ b/site/src/components/SdkCard.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const SdkCard = ({ title, description, links }) => {
+  return (
+    <div className="col-span-1">
+      <h3>{title}</h3>
+      <span>{description}</span>
+      <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
+        <div className="api-card-icon flex-row space-x-4">
+          {links.map(({ href, imgSrc, alt, text }) => (
+            <div className="flex flex-col items-center" key={href}>
+              <a href={href} target="_blank" rel="noopener noreferrer">
+                <img src={imgSrc} alt={alt} />
+              </a>
+              <span className="mt-2 text-sm">{text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SdkCard;

--- a/site/src/components/TbdexSdk.jsx
+++ b/site/src/components/TbdexSdk.jsx
@@ -1,142 +1,77 @@
 import React from 'react';
+import SdkCard from './SdkCard'; 
 
 const TbdexSdk = () => {
   return (
     <div className="not-prose">
       <h1 className="h1 text-primary-yellow mb-12">SDKs</h1>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-
-        <div className="col-span-1">
-          <h3>Protocol</h3>
-          <span>Create, verify, and validate tbDEX messages</span>
-          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
-            <div className="api-card-icon flex-row space-x-4">
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://www.npmjs.com/package/@tbdex/protocol"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
-                    alt="typescript"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Typescript</span>
-              </div>
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://mvnrepository.com/artifact/xyz.block/tbdex-protocol"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
-                    alt="kotlin"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Kotlin</span>
-              </div>
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://swiftpackageindex.com/TBD54566975/tbdex-swift"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg"
-                    alt="swift"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Swift</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="col-span-1">
-          <h3>HTTP Client</h3>
-          <span>Send tbDEX messages to PFIs as a Wallet</span>
-          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
-            <div className="api-card-icon flex-row space-x-4">
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://www.npmjs.com/package/@tbdex/http-client"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
-                    alt="typescript"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Typescript</span>
-              </div>
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://mvnrepository.com/artifact/xyz.block/tbdex-httpclient"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
-                    alt="kotlin"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Kotlin</span>
-              </div>
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://swiftpackageindex.com/TBD54566975/tbdex-swift"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg"
-                    alt="swift"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Swift</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="col-span-1">
-          <h3>HTTP Server</h3>
-          <span>Implement tbDEX API specification as a PFI</span>
-          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
-            <div className="api-card-icon flex-row space-x-4">
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://www.npmjs.com/package/@tbdex/http-server"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
-                    alt="typescript"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Typescript</span>
-              </div>
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://mvnrepository.com/artifact/xyz.block/tbdex-httpserver"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
-                    alt="kotlin"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Kotlin</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
+        <SdkCard
+          title="Protocol"
+          description="Create, verify, and validate tbDEX messages"
+          links={[
+            {
+              href: "https://www.npmjs.com/package/@tbdex/protocol",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg",
+              alt: "typescript",
+              text: "Typescript",
+            },
+            {
+              href: "https://mvnrepository.com/artifact/xyz.block/tbdex-protocol",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg",
+              alt: "kotlin",
+              text: "Kotlin",
+            },
+            {
+              href: "https://swiftpackageindex.com/TBD54566975/tbdex-swift",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg",
+              alt: "swift",
+              text: "Swift",
+            },
+          ]}
+        />
+        <SdkCard
+          title="HTTP Client"
+          description="Send tbDEX messages to PFIs as a Wallet"
+          links={[
+            {
+              href: "https://www.npmjs.com/package/@tbdex/http-client",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg",
+              alt: "typescript",
+              text: "Typescript",
+            },
+            {
+              href: "https://mvnrepository.com/artifact/xyz.block/tbdex-httpclient",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg",
+              alt: "kotlin",
+              text: "Kotlin",
+            },
+            {
+              href: "https://swiftpackageindex.com/TBD54566975/tbdex-swift",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg",
+              alt: "swift",
+              text: "Swift",
+            },
+          ]}
+        />
+        <SdkCard
+          title="HTTP Server"
+          description="Implement tbDEX API specification as a PFI"
+          links={[
+            {
+              href: "https://www.npmjs.com/package/@tbdex/http-server",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg",
+              alt: "typescript",
+              text: "Typescript",
+            },
+            {
+              href: "https://mvnrepository.com/artifact/xyz.block/tbdex-httpserver",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg",
+              alt: "kotlin",
+              text: "Kotlin",
+            },
+          ]}
+        />
       </div>
     </div>
   );

--- a/site/src/components/TbdexSdk.jsx
+++ b/site/src/components/TbdexSdk.jsx
@@ -1,0 +1,145 @@
+import React from 'react';
+
+const TbdexSdk = () => {
+  return (
+    <div className="not-prose">
+      <h1 className="h1 text-primary-yellow mb-12">SDKs</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+
+        <div className="col-span-1">
+          <h3>Protocol</h3>
+          <span>Create, verify, and validate tbDEX messages</span>
+          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
+            <div className="api-card-icon flex-row space-x-4">
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://www.npmjs.com/package/@tbdex/protocol"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
+                    alt="typescript"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Typescript</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://mvnrepository.com/artifact/xyz.block/tbdex-protocol"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
+                    alt="kotlin"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Kotlin</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://swiftpackageindex.com/TBD54566975/tbdex-swift"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg"
+                    alt="swift"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Swift</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-span-1">
+          <h3>HTTP Client</h3>
+          <span>Send tbDEX messages to PFIs as a Wallet</span>
+          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
+            <div className="api-card-icon flex-row space-x-4">
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://www.npmjs.com/package/@tbdex/http-client"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
+                    alt="typescript"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Typescript</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://mvnrepository.com/artifact/xyz.block/tbdex-httpclient"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
+                    alt="kotlin"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Kotlin</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://swiftpackageindex.com/TBD54566975/tbdex-swift"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg"
+                    alt="swift"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Swift</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-span-1">
+          <h3>HTTP Server</h3>
+          <span>Implement tbDEX API specification as a PFI</span>
+          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
+            <div className="api-card-icon flex-row space-x-4">
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://www.npmjs.com/package/@tbdex/http-server"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
+                    alt="typescript"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Typescript</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://mvnrepository.com/artifact/xyz.block/tbdex-httpserver"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
+                    alt="kotlin"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Kotlin</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+};
+
+export default TbdexSdk;

--- a/site/src/components/Web5Sdk.jsx
+++ b/site/src/components/Web5Sdk.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+
+const Web5Sdk = () => {
+  return (
+    <div className="not-prose">
+      <h1 className="h1 text-primary-yellow mb-12">SDKs</h1>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+
+        <div className="col-span-1">
+          <h3>Web5 DIDs</h3>
+          <span>Create and manage decentralized identifiers</span>
+          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
+            <div className="api-card-icon flex-row space-x-4">
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://www.npmjs.com/package/@web5/dids"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
+                    alt="typescript"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Typescript</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://mvnrepository.com/artifact/xyz.block/web5-dids"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
+                    alt="kotlin"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Kotlin</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://swiftpackageindex.com/TBD54566975/web5-swift"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg"
+                    alt="swift"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Swift</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-span-1">
+          <h3>Web5 Credentials</h3>
+          <span>Create and manage verifiable credentials</span>
+          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
+            <div className="api-card-icon flex-row space-x-4">
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://www.npmjs.com/package/@web5/credentials"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
+                    alt="typescript"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Typescript</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://mvnrepository.com/artifact/xyz.block/web5-credentials"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
+                    alt="kotlin"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Kotlin</span>
+              </div>
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://swiftpackageindex.com/TBD54566975/web5-swift"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg"
+                    alt="swift"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Swift</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-span-1">
+          <h3>Web5 DWN API</h3>
+          <span>Create and manage decentralized web nodes</span>
+          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
+            <div className="api-card-icon flex-row space-x-4">
+              <div className="flex flex-col items-center">
+                <a
+                  href="https://www.npmjs.com/package/@web5/api"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
+                    alt="typescript"
+                  />
+                </a>
+                <span className="mt-2 text-sm">Typescript</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+};
+
+export default Web5Sdk;

--- a/site/src/components/Web5Sdk.jsx
+++ b/site/src/components/Web5Sdk.jsx
@@ -1,129 +1,71 @@
 import React from 'react';
+import SdkCard from './SdkCard'; 
 
 const Web5Sdk = () => {
   return (
     <div className="not-prose">
       <h1 className="h1 text-primary-yellow mb-12">SDKs</h1>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-
-        <div className="col-span-1">
-          <h3>Web5 DIDs</h3>
-          <span>Create and manage decentralized identifiers</span>
-          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
-            <div className="api-card-icon flex-row space-x-4">
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://www.npmjs.com/package/@web5/dids"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
-                    alt="typescript"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Typescript</span>
-              </div>
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://mvnrepository.com/artifact/xyz.block/web5-dids"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
-                    alt="kotlin"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Kotlin</span>
-              </div>
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://swiftpackageindex.com/TBD54566975/web5-swift"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg"
-                    alt="swift"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Swift</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="col-span-1">
-          <h3>Web5 Credentials</h3>
-          <span>Create and manage verifiable credentials</span>
-          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
-            <div className="api-card-icon flex-row space-x-4">
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://www.npmjs.com/package/@web5/credentials"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
-                    alt="typescript"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Typescript</span>
-              </div>
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://mvnrepository.com/artifact/xyz.block/web5-credentials"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg"
-                    alt="kotlin"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Kotlin</span>
-              </div>
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://swiftpackageindex.com/TBD54566975/web5-swift"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg"
-                    alt="swift"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Swift</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="col-span-1">
-          <h3>Web5 DWN API</h3>
-          <span>Create and manage decentralized web nodes</span>
-          <div className="api-card flex flex-col bg-transparent border-2 shadow overflow-hidden sm:rounded-sm px-4 py-5 sm:px-6 border-primary-yellow">
-            <div className="api-card-icon flex-row space-x-4">
-              <div className="flex flex-col items-center">
-                <a
-                  href="https://www.npmjs.com/package/@web5/api"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img
-                    src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg"
-                    alt="typescript"
-                  />
-                </a>
-                <span className="mt-2 text-sm">Typescript</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
+        <SdkCard
+          title="Web5 DIDs"
+          description="Create and manage decentralized identifiers"
+          links={[
+            {
+              href: "https://www.npmjs.com/package/@web5/dids",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg",
+              alt: "typescript",
+              text: "Typescript",
+            },
+            {
+              href: "https://mvnrepository.com/artifact/xyz.block/web5-dids",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg",
+              alt: "kotlin",
+              text: "Kotlin",
+            },
+            {
+              href: "https://swiftpackageindex.com/TBD54566975/web5-swift",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg",
+              alt: "swift",
+              text: "Swift",
+            },
+          ]}
+        />
+        <SdkCard
+          title="Web5 Credentials"
+          description="Create and manage verifiable credentials"
+          links={[
+            {
+              href: "https://www.npmjs.com/package/@web5/credentials",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg",
+              alt: "typescript",
+              text: "Typescript",
+            },
+            {
+              href: "https://mvnrepository.com/artifact/xyz.block/web5-credentials",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kotlin/kotlin-original.svg",
+              alt: "kotlin",
+              text: "Kotlin",
+            },
+            {
+              href: "https://swiftpackageindex.com/TBD54566975/web5-swift",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/swift/swift-original.svg",
+              alt: "swift",
+              text: "Swift",
+            },
+          ]}
+        />
+        <SdkCard
+          title="Web5 DWN API"
+          description="Create and manage decentralized web nodes"
+          links={[
+            {
+              href: "https://www.npmjs.com/package/@web5/api",
+              imgSrc: "https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/typescript/typescript-original.svg",
+              alt: "typescript",
+              text: "Typescript",
+            },
+          ]}
+        />
       </div>
     </div>
   );

--- a/site/src/content/projects/web5/web5.js
+++ b/site/src/content/projects/web5/web5.js
@@ -38,34 +38,6 @@ export const content = {
       }
     ],
   },
-  actors: {
-    title: 'Actors',
-    actors: [
-      {
-        title: 'Wallets',
-        description:
-          'wallets act as agents for individuals or institutions by facilitating identity and data interactions',
-      },
-      {
-        title: 'Decentralized Web Nodes (DWNs)',
-        description: 'personal datastores that hold public and encrypted data',
-      },
-      {
-        title: 'Decentralized Web Apps (DWAs)',
-        description:
-          'web apps enhanced with decentralized identity and data storage capabilities',
-      },
-    ],
-    imgDesktop: '/img/actors-web5-desktop.svg',
-    imgMobile: '/img/actors-web5-mobile.svg',
-    isWeb5: true,
-  },
-  web5Illustrations: {
-    imgMobile: '/img/web5-mobile.svg',
-    imgTablet: '/img/web5-tablet.svg',
-    imgDesktop: '/img/web5-desktop.svg',
-    altText: 'Web2 and Web3 to Web5',
-  },
   useCases: {
     title: 'Use Cases',
     pillars: [

--- a/site/src/pages/projects/tbdex.mdx
+++ b/site/src/pages/projects/tbdex.mdx
@@ -5,6 +5,7 @@ hide_table_of_contents: true
 
 import metacontent from '@site/src/content/global-meta';
 import { content } from '@site/src/content/projects/tbdex/tbdex.js';
+import TbdexSdk from '@site/src/components/TbdexSdk.jsx';
 
 <head>
   <title>{content.meta.title}</title>
@@ -28,6 +29,12 @@ import { content } from '@site/src/content/projects/tbdex/tbdex.js';
 <Divider type="slash" />
 
 <ProjectList {...content.components} />
+
+<Divider type="slash" />
+
+<a name="sdk"/>
+
+<TbdexSdk />
 
 <Divider type="slash" />
 

--- a/site/src/pages/projects/web5.mdx
+++ b/site/src/pages/projects/web5.mdx
@@ -5,6 +5,7 @@ hide_table_of_contents: true
 
 import metacontent from '@site/src/content/global-meta';
 import { content } from '@site/src/content/projects/web5/web5.js';
+import Web5Sdk from '@site/src/components/Web5Sdk.jsx';
 
 <head>
   <title>{content.meta.title}</title>
@@ -27,16 +28,18 @@ import { content } from '@site/src/content/projects/web5/web5.js';
 
 <Divider type="slash" />
 
-<PillarList title={content.useCases.title} pillars={content.useCases.pillars} />
-
-<Divider type="slash" />
-
-<Actors content={content.actors} />
-
-<Divider type="slash" />
-
 <a name="components"/>
 
 <ProjectList {...content.components} />
+
+<Divider type="slash" />
+
+<a name="sdk"/>
+
+<Web5Sdk />
+
+<Divider type="slash" />
+
+<PillarList title={content.useCases.title} pillars={content.useCases.pillars} />
 
 </div>


### PR DESCRIPTION
This change adds SDK links to the Project pages for [tbDEX](https://deploy-preview-1564--tbd-website-developer.netlify.app/projects/tbdex/#sdk) and [Web5](https://deploy-preview-1564--tbd-website-developer.netlify.app/projects/web5/#sdk). 

There's 3 new components:

- SdkCard
- TbdexSdk
- Web5Sdk

This PR also includes some additional cosmetic changes, like making non-headers white so it's easier to read, and removing the Web5 actors section of the page.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208214282628240