### PR TITLE
Fix broken link

### DIFF
--- a/site/src/content/projects/web5/web5.js
+++ b/site/src/content/projects/web5/web5.js
@@ -33,7 +33,7 @@ export const content = {
         title: 'Decentralized Web Nodes',
         description: TBDEXProtocol,
         textButton: 'View Component',
-        url: '/docs/web5/decentralized-identifiers/what-are-dwns',
+        url: '/docs/web5/decentralized-web-nodes/what-are-dwns',
         isExternalLink: false,
       }
     ],


### PR DESCRIPTION
[Community member pointed out broken link in Discord](https://discord.com/channels/937858703112155166/1068273971432280196/1280709938280140865)

This pull request includes a small change to the `site/src/content/projects/web5/web5.js` file. The change updates the URL for the "Decentralized Web Nodes" component to point to the correct documentation page.

* [`site/src/content/projects/web5/web5.js`](diffhunk://#diff-d99b27f8e2a2c249f2b9eb258188da5fe2394e2a1e6023f0862de19e29df8098L36-R36): Updated the `url` from `/docs/web5/decentralized-identifiers/what-are-dwns` to `/docs/web5/decentralized-web-nodes/what-are-dwns`.