### PR TITLE
Add missing background to yellow marquee

### DIFF
--- a/site-new/src/pages/component-guide/marquee.mdx
+++ b/site-new/src/pages/component-guide/marquee.mdx
@@ -102,7 +102,7 @@ const marqueeItems = [
 <MarqueeTextSkewed
   texts={["Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "Item 6", "Item 7"]}
   className="text-black"
-  bgColor="Yellow"
+  bgColor="yellow"
   vertical
   pauseOnHover
 />


### PR DESCRIPTION
@dayhaysoos @FahadAminShovon this is a quick bug fix for the new website
I saw the demo was missing a yellow background for the marquee due to a small typo. All fixed! 

