### PR TITLE
Auto adds labels from issue to PR to make leaderboard tracking easier

### DIFF
--- a/.github/workflows/propogate-hacktoberfest-labels.yml
+++ b/.github/workflows/propogate-hacktoberfest-labels.yml
@@ -11,24 +11,36 @@ jobs:
     - name: Get issue number from PR body
       id: issue_number
       run: |
-        issue_number=$(echo "${{ github.event.pull_request.body }}" | grep -oP "(?<=#)\d+")
-        echo "issue_number=$issue_number" >> $GITHUB_OUTPUT
+        issue_number=$(echo "${{ github.event.pull_request.body }}" | grep -oP '(?<=#)\d+' | head -n1)
+        if [ -z "$issue_number" ]; then
+          echo "No issue number found in PR body"
+          echo "has_issue=false" >> $GITHUB_OUTPUT
+        else
+          echo "Issue number found: $issue_number"
+          echo "has_issue=true" >> $GITHUB_OUTPUT
+          echo "issue_number=$issue_number" >> $GITHUB_OUTPUT
+        fi
     - name: Get labels from linked issue
-      if: steps.issue_number.outputs.issue_number != ''
+      if: steps.issue_number.outputs.has_issue == 'true'
       uses: actions/github-script@v6
       id: issue_labels
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const issue_number = ${{ steps.issue_number.outputs.issue_number }};
-          const issue = await github.rest.issues.get({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: issue_number
-          });
-          return issue.data.labels.map(label => label.name);
+          try {
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(issue_number)
+            });
+            return issue.data.labels.map(label => label.name);
+          } catch (error) {
+            console.log(`Error fetching issue labels: ${error}`);
+            return [];
+          }
     - name: Check for required labels
-      if: steps.issue_number.outputs.issue_number != ''
+      if: steps.issue_number.outputs.has_issue == 'true' && steps.issue_labels.outputs.result != '[]'
       id: check_labels
       uses: actions/github-script@v6
       with:
@@ -39,16 +51,21 @@ jobs:
           const sizeLabelPresent = labels.some(label => ['small', 'medium', 'large'].includes(label.toLowerCase()));
           return hacktoberfestLabel || (hacktoberfestLabel && sizeLabelPresent);
     - name: Add labels to PR
-      if: steps.check_labels.outputs.result == 'true'
+      if: steps.issue_number.outputs.has_issue == 'true' && steps.check_labels.outputs.result == 'true'
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const pr_number = context.issue.number;
           const labels = ${{ steps.issue_labels.outputs.result }};
-          await github.rest.issues.addLabels({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: pr_number,
-            labels: labels
-          });
+          try {
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr_number,
+              labels: labels
+            });
+            console.log('Labels added successfully');
+          } catch (error) {
+            console.log(`Error adding labels: ${error}`);
+          }

--- a/.github/workflows/propogate-hacktoberfest-labels.yml
+++ b/.github/workflows/propogate-hacktoberfest-labels.yml
@@ -1,23 +1,18 @@
 name: Propagate Issue Labels to PR
-
 on:
   pull_request:
     types: [opened, synchronize]
-
 jobs:
   copy_labels:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-
     - name: Get issue number from PR body
       id: issue_number
       run: |
         issue_number=$(echo "${{ github.event.pull_request.body }}" | grep -oP "(?<=#)\d+")
-        echo "::set-output name=issue_number::$issue_number"
-
+        echo "issue_number=$issue_number" >> $GITHUB_OUTPUT
     - name: Get labels from linked issue
       if: steps.issue_number.outputs.issue_number != ''
       uses: actions/github-script@v6
@@ -32,9 +27,19 @@ jobs:
             issue_number: issue_number
           });
           return issue.data.labels.map(label => label.name);
-
-    - name: Add labels to PR
+    - name: Check for required labels
       if: steps.issue_number.outputs.issue_number != ''
+      id: check_labels
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const labels = ${{ steps.issue_labels.outputs.result }};
+          const hacktoberfestLabel = labels.some(label => label.toLowerCase().includes('hacktoberfest'));
+          const sizeLabelPresent = labels.some(label => ['small', 'medium', 'large'].includes(label.toLowerCase()));
+          return hacktoberfestLabel || (hacktoberfestLabel && sizeLabelPresent);
+    - name: Add labels to PR
+      if: steps.check_labels.outputs.result == 'true'
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/propogate-hacktoberfest-labels.yml
+++ b/.github/workflows/propogate-hacktoberfest-labels.yml
@@ -1,0 +1,49 @@
+name: Propagate Issue Labels to PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  copy_labels:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Get issue number from PR body
+      id: issue_number
+      run: |
+        issue_number=$(echo "${{ github.event.pull_request.body }}" | grep -oP "(?<=#)\d+")
+        echo "::set-output name=issue_number::$issue_number"
+
+    - name: Get labels from linked issue
+      if: steps.issue_number.outputs.issue_number != ''
+      uses: actions/github-script@v6
+      id: issue_labels
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const issue_number = ${{ steps.issue_number.outputs.issue_number }};
+          const issue = await github.rest.issues.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issue_number
+          });
+          return issue.data.labels.map(label => label.name);
+
+    - name: Add labels to PR
+      if: steps.issue_number.outputs.issue_number != ''
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const pr_number = context.issue.number;
+          const labels = ${{ steps.issue_labels.outputs.result }};
+          await github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr_number,
+            labels: labels
+          });


### PR DESCRIPTION
This GitHub Action automatically adds issue labels (like `hacktoberfest` and size labels -- like small, medium, large) to PRs when the issue is linked, simplifying leaderboard automation.

This pull request introduces a GitHub Actions workflow to automatically propagate labels from linked issues to pull requests. This helps in maintaining consistency and ensuring that relevant labels are applied to PRs based on their associated issues.

### Workflow Automation:

* [`.github/workflows/propogate-hacktoberfest-labels.yml`](diffhunk://#diff-e944122e254eaf98e9b367b05d90a8a05315dc2da49b5f7cdff1742205b4cf11R1-R49): Added a new workflow named "Propagate Issue Labels to PR" which triggers on pull request events (`opened`, `synchronize`). This workflow checks out the repository, extracts the issue number from the PR body, retrieves labels from the linked issue, and applies those labels to the pull request.