### PR TITLE
Action to Auto Update Hacktoberfest Leaderboard

### DIFF
--- a/.github/workflows/update-hacktoberfest-leaderboard.yml
+++ b/.github/workflows/update-hacktoberfest-leaderboard.yml
@@ -1,0 +1,235 @@
+name: Update Hacktoberfest Leaderboard
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # Runs every hour at the start of the hour
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  update-leaderboard:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Update Leaderboard
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.HACKTOBERFEST_LEADERBOARD_TOKEN }}
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const issueNumber = 1680;
+
+          const REPOS = [
+            'TBD54566975/developer.tbd.website',
+            'TBD54566975/web5-js',
+            'TBD54566975/web5-rs',
+            'TBD54566975/dwn-sdk-js',
+            'TBD54566975/tbd-examples',
+            'TBD54566975/didpay',
+            'TBD54566975/did-dht',
+            'TBD54566975/incubation-dcx',
+            'block-open-source/goose-plugins',
+            'csuwildcat/fllw',
+            'csuwildcat/aliased'
+          ];
+
+          const POINT_VALUES = {
+            small: 5,
+            medium: 10,
+            large: 15
+          };
+
+          const calculatePoints = (labels) => {
+            const size = labels.find(label => POINT_VALUES[label.name.toLowerCase()]);
+            return size ? POINT_VALUES[size.name.toLowerCase()] : POINT_VALUES.small;
+          };
+
+          const fetchRecentPRs = async (repo) => {
+            try {
+              console.log(`Fetching recent PRs for ${repo}`);
+              const [repoOwner, repoName] = repo.split('/');
+              
+              const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+              
+              const { data: prs } = await github.rest.pulls.list({
+                owner: repoOwner,
+                repo: repoName,
+                state: 'closed',
+                sort: 'updated',
+                direction: 'desc',
+                per_page: 100
+              });
+
+              console.log(`Fetched ${prs.length} PRs for ${repo}`);
+
+              const hacktoberfestPRs = prs.filter(pr => {
+                const isMerged = !!pr.merged_at;
+                const isRecent = new Date(pr.merged_at) > new Date(thirtyDaysAgo);
+                const isHacktoberfest = pr.labels.some(label => label.name.toLowerCase() === 'hacktoberfest');
+                return isMerged && isRecent && isHacktoberfest;
+              }).map(pr => ({
+                user: pr.user.login,
+                points: calculatePoints(pr.labels),
+                repo: repo,
+                prNumber: pr.number,
+                prTitle: pr.title,
+              }));
+
+              return hacktoberfestPRs;
+            } catch (error) {
+              console.error(`Error fetching PRs for ${repo}: ${error.message}`);
+              return [];
+            }
+          };
+
+          const generateLeaderboard = async () => {
+            try {
+              const allPRs = await Promise.all(REPOS.map(fetchRecentPRs));
+              const flatPRs = allPRs.flat();
+
+              const leaderboard = flatPRs.reduce((acc, pr) => {
+                if (!acc[pr.user]) acc[pr.user] = { points: 0, prs: 0 };
+                acc[pr.user].points += pr.points;
+                acc[pr.user].prs += 1;
+                return acc;
+              }, {});
+
+              const sortedLeaderboard = Object.entries(leaderboard)
+                .sort(([, a], [, b]) => b.points - a.points)
+                .map(([username, data], index) => ({ 
+                  rank: index + 1, 
+                  username, 
+                  points: data.points, 
+                  prs: data.prs 
+                }));
+
+              return sortedLeaderboard;
+            } catch (error) {
+              console.error(`Error generating leaderboard: ${error.message}`);
+              return [];
+            }
+          };
+
+          const updateIssue = async (leaderboardData) => {
+            const issueBody = `# 🏆 TBD Hacktoberfest 2024 Leaderboard 🏆
+          Hello, lovely contributors! As Hacktoberfest 2024 and the crisp Fall breeze refreshes us, we wanted to make the contribution process extra fun. Check our live leaderboard below to see who our top contributors are this year in real-time. Not only does this recognize everyone's efforts, it also brings an amplified competitive vibe with each contribution.
+
+          ### 🌟 **Current Rankings:**
+
+          | Rank | Contributor | Points | PRs |
+          |------|-------------|--------|-----|
+          ${leaderboardData.map(entry => `| ${entry.rank} | @${entry.username} | ${entry.points} | ${entry.prs} |`).join('\n')}
+
+          ### 📜 How It Works:
+          The top 10 contributors with the most points will snag custom swag with this year's exclusive TBD x Hacktoberfest 2024 design. To earn your place in the leaderboard, we have created a points system that is explained below. As you complete a task by successfully merging a PR, you will automatically be granted a certain # of points.
+
+          #### 💯 Point System
+          | Weight | Points Awarded | Description |
+          |---------|-------------|-------------|
+          | 🐭 **Small** | 5 points | For smaller tasks that take limited time to complete and/or don't require any product knowledge. |
+          | 🐰 **Medium** | 10 points | For average tasks that take additional time to complete and/or require some product knowledge. |
+          | 🐂 **Large** | 15 points | For heavy tasks that takes lots of time to complete and/or possibly require deep product knowledge. |
+
+          #### 🎁 Rewards
+          - Made it to the **top 10**? Our Top 10 Contributors with the most points will be awarded TBD x Hacktoberfest 2024 swag from our [TBD shop](https://www.tbd.shop/s/shop). Keep an eye on your progress to make sure you're one step ahead!
+          - Among our **top 3**? Our Top 3 Superstars earn very limited, customized TBD x Hacktoberfest 2024 swag with your name on it. Stay tuned for the reveal!
+
+          ### FAQ
+          - **Frequency of Updates:** The leaderboard will be updated every 1 hour.
+          - **Criteria:** Rankings are based on how many points you earn across all participating TBD repos. To ensure your PRs are successfully merged:
+            - Ensure your contributions are aligned with our [project's CoC](https://developer.tbd.website/open-source/code-of-conduct).
+            - Refer to each participating repo's [Contributing Guide](https://github.com/TBD54566975/developer.tbd.website/blob/main/CONTRIBUTING.md).
+          - **Tie-Breakers:** In the event of a tie, the contributor with the earliest PR merge timestamp will be ranked higher.
+
+
+          ### 🚀 Get Featured:
+          Want to see your name climbing our ranks?
+
+          Explore our issues with the labels \`good-first-issue\` , \`no-code\` and \`hacktoberfest\` in each of our participating repos' Project Hubs:  
+
+          - **developer.tbd.website**: \`MDX\`, \`Javascript\`, \`CSS\`, \`MARKDOWN\`
+            - [Hacktoberfest Project Hub](https://github.com/TBD54566975/developer.tbd.website/issues/1552)
+            - [Contributing Guide](https://github.com/TBD54566975/developer.tbd.website/blob/main/CONTRIBUTING.md)
+
+          - **web5-js**: \`Typescript\`, \`Javascript\`
+            - [Hacktoberfest Project Hub: Protocol Explorer](https://github.com/TBD54566975/tbd-examples/issues/97)
+            - [Hacktoberfest Project Hub: General](https://github.com/TBD54566975/web5-js/issues/908)
+            - [Contributing Guide](https://github.com/TBD54566975/web5-js/blob/main/CONTRIBUTING.md)
+
+          - **web5-rs**: \`Rust\` 
+            - [Hacktoberfest Project Hub](https://github.com/TBD54566975/web5-rs/issues/322)
+            - [Contributing Guide](https://github.com/TBD54566975/web5-rs/blob/main/CONTRIBUTING.md)
+
+          - **dwn-sdk-js**: \`Typescript\`, \`Javascript\`
+            - [Hacktoberfest Project Hub](https://github.com/TBD54566975/dwn-sdk-js/issues/806)
+            - [Contributing Guide](https://github.com/TBD54566975/dwn-sdk-js/blob/main/CONTRIBUTING.md)
+
+          - **DWA starter**: \`Javascript\`
+            - [Hacktoberfest Project Hub: VanillaJS](https://github.com/TBD54566975/tbd-examples/issues/81)
+            - [Hacktoberfest Project Hub: Vue](https://github.com/TBD54566975/tbd-examples/issues/63)
+            - [Contributing Guide](https://github.com/TBD54566975/tbd-examples/blob/main/CONTRIBUTING.md)
+
+          - **DIDPay**: \`Dart\` 
+            - [Hacktoberfest Project Hub](https://github.com/TBD54566975/didpay/issues/298)
+            - [Contributing Guide](https://github.com/TBD54566975/didpay/blob/main/CONTRIBUTING.md)
+
+          - **DID DHT**: \`Go\` 
+            - [Hacktoberfest Project Hub](https://github.com/TBD54566975/did-dht/issues/292)
+            - [Contributing Guide](https://github.com/TBD54566975/did-dht/blob/main/CONTRIBUTING.md)
+
+          - **DCX**: \`TypeScript\`, \`JavaScript\`
+            - [Hacktoberfest Project Hub](https://github.com/TBD54566975/incubation-dcx/labels/hacktoberfest%202024)
+            - [Contributing Guide](https://github.com/TBD54566975/incubation-dcx/blob/main/CONTRIBUTING.md)
+
+          - **Goose Plugins**: \`Python\`
+            - [Hacktoberfest Project Hub](https://github.com/block-open-source/goose-plugins/issues/3)
+            - [Contributing Guide](https://github.com/block-open-source/goose-plugins/blob/main/README.md)
+
+          - **Fllw, Aliased**: \`TypeScript\`, \`JavaScript\`
+            - [Hacktoberfest Task: Fllw](https://github.com/csuwildcat/fllw/issues/7)
+            - [Hacktoberfest Task: Aliased](https://github.com/csuwildcat/aliased/issues/4)
+
+
+          Excited to see everyone's hard work. Thank you so much for your invaluable contributions, and let the fun competition begin! 
+
+          Last updated: ${new Date().toUTCString()}
+          `;
+
+            try {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: issueBody
+              });
+
+              console.log("Issue updated successfully!");
+              console.log("Updated issue body:", issueBody);
+            } catch (error) {
+              throw new Error(`Failed to update issue: ${error.message}`);
+            }
+          };
+
+          // Main execution
+          const leaderboardData = await generateLeaderboard();
+          if (leaderboardData.length > 0) {
+            await updateIssue(leaderboardData);
+          } else {
+            console.log("No leaderboard data to update.");
+            const emptyIssueBody = `
+          # 🏆 TBD Hacktoberfest 2024 Leaderboard 🏆
+          
+          No qualifying PRs found at this time. Check back soon!
+
+          Last updated: ${new Date().toUTCString()}
+          `;
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body: emptyIssueBody
+            });
+            console.log("Updated issue with empty leaderboard message.");
+          }


### PR DESCRIPTION
Adds a Leaderboard traction action

This pull request introduces a new GitHub Actions workflow to automatically update the Hacktoberfest leaderboard on an hourly basis. The workflow fetches recent pull requests from multiple repositories, calculates points based on predefined criteria, and updates a GitHub issue with the current leaderboard standings.

Key changes include:

### New Workflow Addition:
* [`.github/workflows/update-hacktoberfest-leaderboard.yml`](diffhunk://#diff-cf0569e1b17e99543bd8b34845822097e83ff64e84d65474e2144807e0175312R1-R235): Added a new GitHub Actions workflow to update the Hacktoberfest leaderboard hourly and on manual trigger. This includes steps for checking out the repository, fetching recent pull requests, calculating points, generating the leaderboard, and updating the GitHub issue.

### Leaderboard Update Logic:
* Implemented functions to fetch recent pull requests, filter them based on Hacktoberfest criteria, calculate points, and generate a sorted leaderboard.
* Added logic to update a specified GitHub issue with the current leaderboard standings, including a detailed description and point system explanation.