### PR TITLE
Update web5-kt api ref link

### DIFF
--- a/site/docs/api.mdx
+++ b/site/docs/api.mdx
@@ -18,7 +18,7 @@ import ApiCard from '@site/src/components/ApiCard';
       description="A library for generating and resolving Decentralized Identifiers, as well as issuing, presenting and verifying Verifiable Credentials. The JS SDK also includes convenience methods for working with Decentralized Web Nodes."
       links={[
         {"js": "https://tbd54566975.github.io/web5-js/"},
-        {"kt": "https://tbd54566975.github.io/web5-kt/docs/"},
+        {"kt": "https://tbd54566975.github.io/web5-rs/kt/main/"},
         {"swift": "https://swiftpackageindex.com/TBD54566975/web5-swift/main/documentation/web5"}
       ]}
     />


### PR DESCRIPTION
web5-kt is now a part of web5-rs. this PR changes the link of the web5-kt api ref to the new one