### PR TITLE
Lengthened Ambassador Grid

### DIFF
--- a/site/src/components/ExternalContributors.jsx
+++ b/site/src/components/ExternalContributors.jsx
@@ -112,7 +112,7 @@ const checkboxLabelText = {
 };
 
 const scrollableContainerStyle = {
-  maxHeight: '750px',
+  maxHeight: '850px',
   overflowY: 'auto',
   padding: '0 20px',
   marginBottom: '20px',


### PR DESCRIPTION
Made height of Ambassadors Grid a bit longer so that cards aren't cut off.

**Before**

<img width="1417" alt="image" src="https://github.com/user-attachments/assets/426e194e-e48c-4f0d-8bc5-513668968e90">

**After**

<img width="1443" alt="image" src="https://github.com/user-attachments/assets/2fd43d4c-7651-4ae5-8186-b80af7c747a9">
